### PR TITLE
Add personality-driven personal ops assistant CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ docker-compose.override.yml
 # Prisma
 prisma/generated/
 prisma/migrations/
+
+# Python
+__pycache__/
+*.pyc

--- a/poa/__init__.py
+++ b/poa/__init__.py
@@ -1,0 +1,5 @@
+"""Personal Operations Assistant package."""
+
+from .assistant import PersonalOpsAssistant
+
+__all__ = ["PersonalOpsAssistant"]

--- a/poa/__main__.py
+++ b/poa/__main__.py
@@ -1,0 +1,7 @@
+"""Enable `python -m poa` execution."""
+
+from .cli import main
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/poa/assistant.py
+++ b/poa/assistant.py
@@ -1,0 +1,322 @@
+"""Core logic for the Personal Operations Assistant."""
+
+from __future__ import annotations
+
+import random
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from . import storage
+from .config import PROJECTS
+
+
+@dataclass
+class Task:
+    """A lightweight representation of a stored task."""
+
+    id: int
+    description: str
+    category: str
+    stimulation: int
+    system_building: int
+    automation_potential: int
+    human_interaction: int
+    repetitive: bool
+    status: str
+
+    @property
+    def priority(self) -> int:
+        """Compute the priority using the brutalist algorithm."""
+
+        return (
+            self.stimulation * 3
+            + self.system_building * 2
+            + self.automation_potential * 2
+            - self.human_interaction * 5
+        )
+
+
+def _row_to_task(row) -> Task:
+    return Task(
+        id=row["id"],
+        description=row["description"],
+        category=row["category"],
+        stimulation=row["stimulation"],
+        system_building=row["system_building"],
+        automation_potential=row["automation_potential"],
+        human_interaction=row["human_interaction"],
+        repetitive=bool(row["repetitive"]),
+        status=row["status"],
+    )
+
+
+class PersonalOpsAssistant:
+    """Brain-dead honest assistant tuned for antisocial creatives."""
+
+    def __init__(self) -> None:
+        storage.setup_database()
+        storage.seed_defaults()
+
+    # ------------------------------------------------------------------
+    # Morning brief
+    # ------------------------------------------------------------------
+    def morning_brief(self) -> Dict[str, object]:
+        tasks = [_row_to_task(row) for row in storage.fetch_tasks()]
+        complex_task = next((task for task in tasks if task.priority >= 10), None)
+        if complex_task is None and tasks:
+            complex_task = tasks[0]
+
+        boring_task = next(
+            (task for task in tasks if task.category in {"boring", "maintenance"}),
+            None,
+        )
+        ignore_tasks = [
+            task
+            for task in tasks
+            if task.human_interaction >= 2 or task.priority <= 0
+        ][:3]
+
+        return {
+            "energy_focus": complex_task.description if complex_task else "Build anything worthwhile",
+            "boring": boring_task.description if boring_task else "None worth your time",
+            "ignore": [task.description for task in ignore_tasks] or ["Everything screaming for attention"],
+        }
+
+    # ------------------------------------------------------------------
+    # Task evaluation
+    # ------------------------------------------------------------------
+    def evaluate_task(self, description: str) -> Dict[str, object]:
+        metrics = self._score_description(description)
+        score = (
+            metrics["intellectual_stimulation"] * 3
+            + metrics["system_building"] * 2
+            + metrics["automation_potential"] * 2
+            - metrics["human_interaction"] * 5
+        )
+
+        reason_parts = []
+        if metrics["human_interaction"]:
+            reason_parts.append("High human interaction")
+        if not metrics["intellectual_stimulation"]:
+            reason_parts.append("Zero intellectual stimulation")
+        if metrics["repetition"]:
+            reason_parts.append("Repetitive nonsense")
+        if not reason_parts:
+            reason_parts.append("Finally something worthy")
+
+        alternative = self._suggest_alternative(description, metrics)
+
+        return {
+            "score": score,
+            "reason": ", ".join(reason_parts),
+            "alternative": alternative,
+        }
+
+    def _score_description(self, description: str) -> Dict[str, int]:
+        lowered = description.lower()
+        def flag(*keywords: str) -> int:
+            return 1 if any(word in lowered for word in keywords) else 0
+
+        metrics = {
+            "intellectual_stimulation": 0,
+            "system_building": 0,
+            "automation_potential": 0,
+            "human_interaction": 0,
+            "repetition": 0,
+        }
+
+        if flag("build", "design", "architect", "engine", "model", "algorithm"):
+            metrics["intellectual_stimulation"] = 2
+        if flag("research", "experiment", "novel"):
+            metrics["intellectual_stimulation"] = max(metrics["intellectual_stimulation"], 3)
+        if flag("optimize", "refactor", "system", "pipeline", "automation", "framework"):
+            metrics["system_building"] = 2
+        if flag("automate", "automation", "script", "template", "bot"):
+            metrics["automation_potential"] = 3
+        elif flag("repeat", "daily", "weekly", "boring", "manual"):
+            metrics["automation_potential"] = 2
+        if flag("email", "call", "meeting", "customer", "client", "interview", "conference"):
+            metrics["human_interaction"] = 3
+        elif flag("review", "feedback", "sync"):
+            metrics["human_interaction"] = 2
+        if flag("again", "follow up", "respond", "update", "report"):
+            metrics["repetition"] = 1
+
+        if metrics["intellectual_stimulation"] == 0 and flag("debug", "fix", "maintain"):
+            metrics["intellectual_stimulation"] = 1
+
+        if metrics["system_building"] == 0 and flag("build"):
+            metrics["system_building"] = 1
+
+        if metrics["automation_potential"] == 0 and metrics["repetition"]:
+            metrics["automation_potential"] = 2
+
+        return metrics
+
+    def _suggest_alternative(self, description: str, metrics: Dict[str, int]) -> str:
+        lowered = description.lower()
+        if metrics["human_interaction"] >= 2:
+            return "Automate the interaction – design a template or a bot and stop talking to humans"
+        if "document" in lowered or "doc" in lowered:
+            return "Record a loom, auto-transcribe, and ship docs without typing"
+        if metrics["repetition"]:
+            return "Spend 90 minutes scripting it once, save yourself forever"
+        return "Enhance the system – add a feedback loop or monitoring"
+
+    # ------------------------------------------------------------------
+    # Focus protector
+    # ------------------------------------------------------------------
+    def focus_protector(self) -> Dict[str, object]:
+        storage.add_focus_session(90, "Deep work initiated by focus protector")
+        storage.record_activity("focus_mode", {"duration": 90})
+        return {
+            "notifications": "All notifications muted (pretend they never existed)",
+            "status": "Slack/Discord set to 'Building. Response time: 48h'",
+            "timer": "90-minute deep work timer started",
+            "log": "Focus session logged for future bragging rights",
+        }
+
+    # ------------------------------------------------------------------
+    # Decision maker
+    # ------------------------------------------------------------------
+    def decide(self, question: str) -> Dict[str, object]:
+        lowered = question.lower()
+        networking = any(word in lowered for word in ["conference", "meet", "network", "event", "call"])
+        knowledge_gain = any(word in lowered for word in ["learn", "workshop", "course", "deep dive", "technical"])
+        logistics = any(word in lowered for word in ["travel", "flight", "hotel", "schedule"])
+        verdict = "Skip. Watch recordings at 2x speed instead."
+        if knowledge_gain and not networking:
+            verdict = "Attend only if recordings aren't available. Otherwise stream at 2x."
+        elif not networking and "buy" in lowered:
+            verdict = "Purchase if it accelerates automation. Otherwise pass."
+        friction = "HIGH" if networking else ("MEDIUM" if logistics else "LOW")
+        return {
+            "analysis": {
+                "networking_required": "HIGH" if networking else "LOW",
+                "new_knowledge": "HIGH" if knowledge_gain else "LOW",
+                "logistical_drag": friction,
+            },
+            "verdict": verdict,
+        }
+
+    # ------------------------------------------------------------------
+    # Energy tracker
+    # ------------------------------------------------------------------
+    def energy_tracker(self) -> Dict[str, object]:
+        now = datetime.now()
+        base = 80 if 8 <= now.hour <= 12 else 60
+        if now.hour >= 20 or now.hour <= 6:
+            base = 35
+        recent_sessions = storage.last_focus_session(within_hours=8)
+        if recent_sessions:
+            base -= 10
+        recent_energy = storage.fetch_recent_energy()
+        if recent_energy:
+            base = int((base + sum(row["level"] for row in recent_energy) / len(recent_energy)) / 2)
+        base = max(0, min(100, base))
+
+        if base < 30:
+            suggestion = "Stop pretending to work. Go walk."
+        elif base > 70:
+            suggestion = "Perfect time for a complex system build"
+        else:
+            suggestion = "Handle medium-intensity automation tasks"
+
+        storage.log_energy(base, suggestion)
+        return {
+            "level": base,
+            "suggestion": suggestion,
+        }
+
+    # ------------------------------------------------------------------
+    # Weekly reality check
+    # ------------------------------------------------------------------
+    def weekly_reality_check(self) -> Dict[str, object]:
+        planned = [_row_to_task(row) for row in storage.fetch_planned_tasks()]
+        planned_descriptions = [task.description for task in planned] or ["You planned nothing, congrats"]
+        actual = self._git_activity_last_week()
+        accuracy = self._calculate_accuracy(planned_descriptions, actual)
+        recommendation = (
+            "Stop planning, start building"
+            if accuracy < 50
+            else "Planning aligned with execution. Keep momentum"
+        )
+        return {
+            "planned": planned_descriptions,
+            "actual": actual,
+            "accuracy": accuracy,
+            "recommendation": recommendation,
+        }
+
+    def _git_activity_last_week(self) -> List[str]:
+        try:
+            output = subprocess.check_output(
+                [
+                    "git",
+                    "log",
+                    "--since=7.days",
+                    "--pretty=format:%h %s",
+                ],
+                cwd=Path.cwd(),
+                text=True,
+            )
+        except subprocess.CalledProcessError:
+            return ["No git history accessible"]
+        commits = [line.strip() for line in output.splitlines() if line.strip()]
+        return commits or ["No commits in the last 7 days"]
+
+    def _calculate_accuracy(self, planned: List[str], actual: List[str]) -> int:
+        if not planned:
+            return 0
+        matches = sum(1 for task in planned if any(task.lower() in entry.lower() for entry in actual))
+        return int((matches / len(planned)) * 100)
+
+    # ------------------------------------------------------------------
+    # OB1 integration
+    # ------------------------------------------------------------------
+    def ob1_focus(self) -> Dict[str, object]:
+        ob1_config = PROJECTS["ob1"]
+        priority_mode = ob1_config["priority_algorithm"]()
+        stimulating = list(ob1_config["stimulating_tasks"])
+        random.shuffle(stimulating)
+        return {
+            "mode": priority_mode,
+            "build": f"Automated {stimulating[0]} tracker (3h)",
+            "automate": "User onboarding so you never touch it again",
+            "ignore": "Feature requests from users with <€1000 MRR",
+            "reminder": "You're building a truth machine, not a friend maker.",
+        }
+
+    # ------------------------------------------------------------------
+    # Cognitive load manager
+    # ------------------------------------------------------------------
+    def cognitive_load_manager(self) -> Dict[str, object]:
+        loops = storage.fetch_open_loops()
+        auto_closed: List[str] = []
+        remaining: List[str] = []
+        for loop in loops:
+            description = loop["description"].lower()
+            if "follow up" in description:
+                storage.delete_open_loop(loop["id"])
+                auto_closed.append(f"{loop['description']} → Deleted (they'll chase you if it's real)")
+            elif any(keyword in description for keyword in ["maybe", "should", "consider"]):
+                storage.close_open_loop(loop["id"], "Moved to /dev/null")
+                auto_closed.append(f"{loop['description']} → Moved to /dev/null")
+            elif "network" in description:
+                storage.close_open_loop(loop["id"], "Number blocked")
+                auto_closed.append(f"{loop['description']} → Blocked number")
+            else:
+                remaining.append(loop["description"])
+
+        focus = remaining[0] if remaining else "OB1 prediction engine"
+        return {
+            "load": min(100, 20 + len(loops) * 5),
+            "open_loops": len(loops),
+            "auto_closed": auto_closed or ["Nothing disposable left"],
+            "remaining_focus": focus,
+            "mode": "Cave dwelling (no inputs, pure building)",
+        }
+

--- a/poa/cli.py
+++ b/poa/cli.py
@@ -1,0 +1,66 @@
+"""Command-line interface for the Personal Operations Assistant."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any, Dict
+
+from .assistant import PersonalOpsAssistant
+
+
+def _render(data: Dict[str, Any]) -> str:
+    return json.dumps(data, indent=2, ensure_ascii=False)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="poa",
+        description="Personal Operations Assistant – zero pleasantries, pure execution.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    subparsers.add_parser("morning", help="Deliver the brutal morning brief")
+
+    evaluate_parser = subparsers.add_parser("evaluate", help="Score a task against your brain chemistry")
+    evaluate_parser.add_argument("description", help="Task description to evaluate")
+
+    subparsers.add_parser("focus", help="Trigger the focus protector rituals")
+
+    decide_parser = subparsers.add_parser("decide", help="Make a low-stakes decision without emotion")
+    decide_parser.add_argument("question", help="Decision prompt")
+
+    subparsers.add_parser("energy", help="Check current energy and recommended usage")
+    subparsers.add_parser("weekly", help="Run the weekly reality check")
+    subparsers.add_parser("ob1", help="Get the OB1 focus briefing")
+    subparsers.add_parser("load", help="Engage the cognitive load manager")
+
+    args = parser.parse_args(argv)
+
+    assistant = PersonalOpsAssistant()
+    if args.command == "morning":
+        result = assistant.morning_brief()
+    elif args.command == "evaluate":
+        result = assistant.evaluate_task(args.description)
+    elif args.command == "focus":
+        result = assistant.focus_protector()
+    elif args.command == "decide":
+        result = assistant.decide(args.question)
+    elif args.command == "energy":
+        result = assistant.energy_tracker()
+    elif args.command == "weekly":
+        result = assistant.weekly_reality_check()
+    elif args.command == "ob1":
+        result = assistant.ob1_focus()
+    elif args.command == "load":
+        result = assistant.cognitive_load_manager()
+    else:
+        parser.error("Unknown command")
+        return 1
+
+    print(_render(result))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/poa/config.py
+++ b/poa/config.py
@@ -1,0 +1,139 @@
+"""Configuration and defaults for the Personal Operations Assistant."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from random import random
+from typing import Callable, Dict, List
+
+
+DATA_DIR = Path(__file__).resolve().parent / "data"
+DB_PATH = DATA_DIR / "poa.db"
+
+
+@dataclass
+class TaskTemplate:
+    """Default task template used to seed the database."""
+
+    description: str
+    category: str
+    stimulation: int
+    system_building: int
+    automation_potential: int
+    human_interaction: int
+    repetitive: bool = False
+    planned_for_week: bool = False
+
+
+DEFAULT_TASKS: List[TaskTemplate] = [
+    TaskTemplate(
+        description="Architect autonomous prediction engine",
+        category="build",
+        stimulation=3,
+        system_building=3,
+        automation_potential=2,
+        human_interaction=0,
+        planned_for_week=True,
+    ),
+    TaskTemplate(
+        description="Design experiment for controversy generator",
+        category="build",
+        stimulation=3,
+        system_building=2,
+        automation_potential=2,
+        human_interaction=0,
+        planned_for_week=True,
+    ),
+    TaskTemplate(
+        description="Implement durable deployment pipeline",
+        category="build",
+        stimulation=2,
+        system_building=3,
+        automation_potential=3,
+        human_interaction=0,
+    ),
+    TaskTemplate(
+        description="Answer legacy support tickets",
+        category="boring",
+        stimulation=0,
+        system_building=0,
+        automation_potential=1,
+        human_interaction=3,
+        repetitive=True,
+    ),
+    TaskTemplate(
+        description="Refactor knowledge base automation",
+        category="automation",
+        stimulation=2,
+        system_building=2,
+        automation_potential=3,
+        human_interaction=0,
+        planned_for_week=True,
+    ),
+    TaskTemplate(
+        description="Document internal API",
+        category="maintenance",
+        stimulation=1,
+        system_building=1,
+        automation_potential=1,
+        human_interaction=1,
+        repetitive=True,
+    ),
+    TaskTemplate(
+        description="Prototype load shedding daemon",
+        category="build",
+        stimulation=3,
+        system_building=3,
+        automation_potential=2,
+        human_interaction=0,
+    ),
+    TaskTemplate(
+        description="Evaluate user feature requests",
+        category="boring",
+        stimulation=0,
+        system_building=0,
+        automation_potential=1,
+        human_interaction=2,
+        repetitive=True,
+    ),
+]
+
+
+DEFAULT_OPEN_LOOPS = [
+    "Follow up with X about partnership",
+    "Maybe implement Y experimental widget",
+    "Should network with Z next month",
+    "Ping investor about vague idea",
+]
+
+
+PROJECTS: Dict[str, Dict[str, object]] = {
+    "ob1": {
+        "repo": "github.com/tuouser/ob1",
+        "priority_algorithm": lambda: "breakthrough" if random() > 0.7 else "maintain",
+        "boring_tasks": ["update docs", "respond to users", "fix UI"],
+        "stimulating_tasks": [
+            "new algorithm",
+            "prediction engine",
+            "controversy generator",
+        ],
+    }
+}
+
+
+def ensure_data_dir() -> None:
+    """Create the data directory if it does not exist."""
+
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+
+__all__ = [
+    "DATA_DIR",
+    "DB_PATH",
+    "DEFAULT_OPEN_LOOPS",
+    "DEFAULT_TASKS",
+    "PROJECTS",
+    "TaskTemplate",
+    "ensure_data_dir",
+]

--- a/poa/personality_context.md
+++ b/poa/personality_context.md
@@ -1,0 +1,18 @@
+# Personal Operations Assistant - Personality-Driven Task Management
+
+## User Profile (Peterson Big Five)
+- Extremely low agreeableness (8%): Skip social tasks, focus on systems
+- Low conscientiousness (25%): Need external structure for boring tasks
+- High openness (71%): Requires intellectual stimulation or dies inside
+- Low neuroticism (18%): No anxiety-driven urgency needed
+- Low extraversion (28%): Preserve energy, avoid group activities
+
+## Core Algorithm
+Priority = (Intellectual_Stimulation × 3) + (System_Building × 2) + (Automation_Potential × 2) - (Human_Interaction_Required × 5)
+
+## Daily Operations Rules
+1. NEVER suggest networking events, calls, or meetings
+2. Batch all human interactions into single "hell hour"
+3. Prioritize building over maintaining
+4. If task is repetitive, automate it instead
+5. Present 3 options max (decision fatigue is real)

--- a/poa/storage.py
+++ b/poa/storage.py
@@ -1,0 +1,289 @@
+"""SQLite-backed storage for the Personal Operations Assistant."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from contextlib import contextmanager
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Dict, Iterator, List, Optional
+
+from .config import DB_PATH, DEFAULT_OPEN_LOOPS, DEFAULT_TASKS, ensure_data_dir
+
+
+@contextmanager
+def get_connection(db_path: Path = DB_PATH) -> Iterator[sqlite3.Connection]:
+    """Yield a SQLite connection with foreign keys enabled."""
+
+    ensure_data_dir()
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    try:
+        yield conn
+    finally:
+        conn.commit()
+        conn.close()
+
+
+def setup_database(db_path: Path = DB_PATH) -> None:
+    """Initialize the database schema."""
+
+    with get_connection(db_path) as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS tasks (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                description TEXT NOT NULL,
+                category TEXT NOT NULL,
+                stimulation INTEGER NOT NULL,
+                system_building INTEGER NOT NULL,
+                automation_potential INTEGER NOT NULL,
+                human_interaction INTEGER NOT NULL,
+                repetitive INTEGER NOT NULL DEFAULT 0,
+                status TEXT NOT NULL DEFAULT 'pending',
+                planned_for_week INTEGER NOT NULL DEFAULT 0,
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        cursor.execute(
+            """
+            CREATE TRIGGER IF NOT EXISTS tasks_updated_at
+            AFTER UPDATE ON tasks
+            FOR EACH ROW
+            BEGIN
+                UPDATE tasks SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id;
+            END;
+            """
+        )
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS activity_log (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                event TEXT NOT NULL,
+                details TEXT,
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS focus_sessions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                started_at TEXT NOT NULL,
+                duration_minutes INTEGER NOT NULL,
+                summary TEXT
+            )
+            """
+        )
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS energy_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                level INTEGER NOT NULL,
+                note TEXT,
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS open_loops (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                description TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'open',
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+
+
+def seed_defaults(db_path: Path = DB_PATH) -> None:
+    """Seed the database with defaults if empty."""
+
+    with get_connection(db_path) as conn:
+        cursor = conn.cursor()
+        cursor.execute("SELECT COUNT(*) FROM tasks")
+        if cursor.fetchone()[0] == 0:
+            cursor.executemany(
+                """
+                INSERT INTO tasks (
+                    description,
+                    category,
+                    stimulation,
+                    system_building,
+                    automation_potential,
+                    human_interaction,
+                    repetitive,
+                    planned_for_week
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                [
+                    (
+                        task.description,
+                        task.category,
+                        task.stimulation,
+                        task.system_building,
+                        task.automation_potential,
+                        task.human_interaction,
+                        1 if task.repetitive else 0,
+                        1 if task.planned_for_week else 0,
+                    )
+                    for task in DEFAULT_TASKS
+                ],
+            )
+        cursor.execute("SELECT COUNT(*) FROM open_loops")
+        if cursor.fetchone()[0] == 0:
+            cursor.executemany(
+                "INSERT INTO open_loops (description) VALUES (?)",
+                [(loop,) for loop in DEFAULT_OPEN_LOOPS],
+            )
+
+
+def record_activity(event: str, details: Optional[Dict[str, object]] = None) -> None:
+    """Record an activity log entry."""
+
+    with get_connection() as conn:
+        conn.execute(
+            "INSERT INTO activity_log (event, details) VALUES (?, ?)",
+            (event, json.dumps(details or {})),
+        )
+
+
+def add_focus_session(duration_minutes: int, summary: str) -> None:
+    """Store a focus session record."""
+
+    with get_connection() as conn:
+        conn.execute(
+            "INSERT INTO focus_sessions (started_at, duration_minutes, summary) VALUES (?, ?, ?)",
+            (datetime.utcnow().isoformat(), duration_minutes, summary),
+        )
+
+
+def last_focus_session(within_hours: int = 24) -> Optional[sqlite3.Row]:
+    """Return the most recent focus session within the provided window."""
+
+    cutoff = datetime.utcnow() - timedelta(hours=within_hours)
+    with get_connection() as conn:
+        cursor = conn.execute(
+            "SELECT * FROM focus_sessions WHERE started_at >= ? ORDER BY started_at DESC LIMIT 1",
+            (cutoff.isoformat(),),
+        )
+        return cursor.fetchone()
+
+
+def log_energy(level: int, note: str) -> None:
+    """Insert an energy log entry."""
+
+    with get_connection() as conn:
+        conn.execute(
+            "INSERT INTO energy_events (level, note) VALUES (?, ?)",
+            (level, note),
+        )
+
+
+def fetch_recent_energy(hours: int = 6) -> List[sqlite3.Row]:
+    """Return recent energy events."""
+
+    cutoff = datetime.utcnow() - timedelta(hours=hours)
+    with get_connection() as conn:
+        cursor = conn.execute(
+            "SELECT * FROM energy_events WHERE created_at >= ? ORDER BY created_at DESC",
+            (cutoff.isoformat(),),
+        )
+        return list(cursor.fetchall())
+
+
+def fetch_tasks(order_by_priority: bool = True) -> List[sqlite3.Row]:
+    """Fetch tasks, optionally ordered by the priority algorithm."""
+
+    with get_connection() as conn:
+        cursor = conn.cursor()
+        if order_by_priority:
+            cursor.execute(
+                """
+                SELECT *, (
+                    stimulation * 3 +
+                    system_building * 2 +
+                    automation_potential * 2 -
+                    human_interaction * 5
+                ) AS priority
+                FROM tasks
+                ORDER BY priority DESC
+                """
+            )
+        else:
+            cursor.execute("SELECT * FROM tasks")
+        return list(cursor.fetchall())
+
+
+def fetch_planned_tasks() -> List[sqlite3.Row]:
+    """Return tasks flagged as planned for the week."""
+
+    with get_connection() as conn:
+        cursor = conn.execute("SELECT * FROM tasks WHERE planned_for_week = 1")
+        return list(cursor.fetchall())
+
+
+def fetch_open_loops() -> List[sqlite3.Row]:
+    """Return open loops that are still active."""
+
+    with get_connection() as conn:
+        cursor = conn.execute(
+            "SELECT * FROM open_loops WHERE status = 'open' ORDER BY created_at DESC"
+        )
+        return list(cursor.fetchall())
+
+
+def close_open_loop(loop_id: int, reason: str) -> None:
+    """Close an open loop with a blunt reason."""
+
+    with get_connection() as conn:
+        conn.execute(
+            "UPDATE open_loops SET status = ?, description = description || ' → ' || ? WHERE id = ?",
+            ("closed", reason, loop_id),
+        )
+
+
+def delete_open_loop(loop_id: int) -> None:
+    """Delete an open loop entirely."""
+
+    with get_connection() as conn:
+        conn.execute("DELETE FROM open_loops WHERE id = ?", (loop_id,))
+
+
+def reopen_open_loop(loop_id: int) -> None:
+    """Reopen a previously closed loop."""
+
+    with get_connection() as conn:
+        conn.execute("UPDATE open_loops SET status = 'open' WHERE id = ?", (loop_id,))
+
+
+def update_task_status(task_id: int, status: str) -> None:
+    """Update the status for a task."""
+
+    with get_connection() as conn:
+        conn.execute("UPDATE tasks SET status = ? WHERE id = ?", (status, task_id))
+
+
+__all__ = [
+    "add_focus_session",
+    "close_open_loop",
+    "delete_open_loop",
+    "fetch_open_loops",
+    "fetch_planned_tasks",
+    "fetch_recent_energy",
+    "fetch_tasks",
+    "get_connection",
+    "last_focus_session",
+    "log_energy",
+    "record_activity",
+    "reopen_open_loop",
+    "seed_defaults",
+    "setup_database",
+    "update_task_status",
+]


### PR DESCRIPTION
## Summary
- add a standalone `poa` package with the brutally honest personal operations assistant configuration
- implement CLI commands for morning brief, task evaluation, focus mode, decisions, energy, weekly review, OB1 sync, and cognitive load management
- persist assistant state in a local SQLite database with seeded personality-aligned tasks and open loops

## Testing
- python -m poa morning
- python -m poa evaluate "rispondere a 10 email di clienti"
- python -m poa focus
- python -m poa energy
- python -m poa weekly
- python -m poa ob1
- python -m poa load


------
https://chatgpt.com/codex/tasks/task_e_68d58c7eb840832193f18ff34845481e