### PR TITLE
Add invasive Bray Android watcher app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ docker-compose.override.yml
 # Prisma
 prisma/generated/
 prisma/migrations/
+
+# Python
+__pycache__/
+*.pyc

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,0 +1,27 @@
+apply plugin: 'com.android.application'
+apply plugin: 'org.jetbrains.kotlin.android'
+
+android {
+    namespace 'com.bray.watcher'
+    compileSdk 33
+
+    defaultConfig {
+        applicationId "com.bray.watcher"
+        minSdk 26
+        targetSdk 33
+        versionCode 1
+        versionName "1.0"
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+}
+
+dependencies {
+    implementation 'com.squareup.okhttp3:okhttp:4.10.0'
+    implementation 'com.google.code.gson:gson:2.10'
+}

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,75 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.bray.watcher">
+
+    <uses-permission android:name="android.permission.PACKAGE_USAGE_STATS" />
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
+    <uses-permission android:name="android.permission.KILL_BACKGROUND_PROCESSES" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.ACCESS_NOTIFICATION_POLICY" />
+    <uses-permission android:name="android.permission.WRITE_SECURE_SETTINGS" />
+
+    <application
+        android:allowBackup="false"
+        android:label="Bray"
+        android:icon="@drawable/eye">
+
+        <service
+            android:name=".BrayService"
+            android:enabled="true"
+            android:exported="false"
+            android:foregroundServiceType="dataSync" />
+
+        <service
+            android:name=".BrayAccessibilityService"
+            android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE">
+            <intent-filter>
+                <action android:name="android.accessibilityservice.AccessibilityService" />
+            </intent-filter>
+            <meta-data
+                android:name="android.accessibilityservice"
+                android:resource="@xml/accessibility_service_config" />
+        </service>
+
+        <receiver android:name=".BrayWidget">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/bray_widget_info" />
+        </receiver>
+
+        <service
+            android:name=".BrayTileService"
+            android:icon="@drawable/eye"
+            android:label="Bray"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+            <intent-filter>
+                <action android:name="android.service.quicksettings.TileService" />
+            </intent-filter>
+        </service>
+
+        <receiver
+            android:name=".BootReceiver"
+            android:enabled="true"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
+
+        <receiver
+            android:name=".BrayDeviceAdminReceiver"
+            android:permission="android.permission.BIND_DEVICE_ADMIN">
+            <meta-data
+                android:name="android.app.device_admin"
+                android:resource="@xml/device_admin" />
+            <intent-filter>
+                <action android:name="android.app.action.DEVICE_ADMIN_ENABLED" />
+            </intent-filter>
+        </receiver>
+
+    </application>
+
+</manifest>

--- a/android/app/src/main/java/com/bray/watcher/BootReceiver.java
+++ b/android/app/src/main/java/com/bray/watcher/BootReceiver.java
@@ -1,0 +1,25 @@
+package com.bray.watcher;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+/**
+ * Ensures Bray resumes control immediately after boot.
+ */
+public class BootReceiver extends BroadcastReceiver {
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        if (intent == null || intent.getAction() == null) {
+            return;
+        }
+        if (Intent.ACTION_BOOT_COMPLETED.equals(intent.getAction())) {
+            Intent serviceIntent = new Intent(context, BrayService.class);
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+                context.startForegroundService(serviceIntent);
+            } else {
+                context.startService(serviceIntent);
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/bray/watcher/BrayAccessibilityService.kt
+++ b/android/app/src/main/java/com/bray/watcher/BrayAccessibilityService.kt
@@ -1,0 +1,71 @@
+package com.bray.watcher
+
+import android.accessibilityservice.AccessibilityService
+import android.accessibilityservice.AccessibilityServiceInfo
+import android.graphics.PixelFormat
+import android.os.Handler
+import android.os.Looper
+import android.view.LayoutInflater
+import android.view.WindowManager
+import android.view.accessibility.AccessibilityEvent
+import android.widget.TextView
+
+/**
+ * Accessibility layer that force-closes distracting apps or shames the user with an overlay.
+ */
+class BrayAccessibilityService : AccessibilityService() {
+
+    private val distractingApps = setOf(
+        "com.instagram.android",
+        "com.twitter.android",
+        "com.reddit.frontpage",
+        "com.facebook.katana",
+        "com.zhiliaoapp.musically",
+        "com.google.android.youtube"
+    )
+
+    override fun onServiceConnected() {
+        super.onServiceConnected()
+        serviceInfo = serviceInfo.apply {
+            eventTypes = AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED
+            feedbackType = AccessibilityServiceInfo.FEEDBACK_GENERIC
+            notificationTimeout = 100
+        }
+    }
+
+    override fun onAccessibilityEvent(event: AccessibilityEvent) {
+        if (event.eventType != AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED) return
+
+        val packageName = event.packageName?.toString() ?: return
+        if (!distractingApps.contains(packageName)) return
+
+        performGlobalAction(GLOBAL_ACTION_BACK)
+        performGlobalAction(GLOBAL_ACTION_HOME)
+        showShameOverlay(packageName)
+    }
+
+    override fun onInterrupt() {
+        // Nothing to clean up
+    }
+
+    private fun showShameOverlay(packageName: String) {
+        val wm = getSystemService(WINDOW_SERVICE) as WindowManager
+        val overlay = LayoutInflater.from(this).inflate(R.layout.shame_overlay, null)
+        overlay.findViewById<TextView>(R.id.shame_text).text =
+            "STOP. ${packageName}\nOB1 made €0 while you scrolled."
+
+        val params = WindowManager.LayoutParams(
+            WindowManager.LayoutParams.MATCH_PARENT,
+            WindowManager.LayoutParams.WRAP_CONTENT,
+            WindowManager.LayoutParams.TYPE_ACCESSIBILITY_OVERLAY,
+            WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE,
+            PixelFormat.TRANSLUCENT
+        )
+
+        wm.addView(overlay, params)
+
+        Handler(Looper.getMainLooper()).postDelayed({
+            wm.removeView(overlay)
+        }, 3000)
+    }
+}

--- a/android/app/src/main/java/com/bray/watcher/BrayDeviceAdminReceiver.java
+++ b/android/app/src/main/java/com/bray/watcher/BrayDeviceAdminReceiver.java
@@ -1,0 +1,21 @@
+package com.bray.watcher;
+
+import android.app.admin.DeviceAdminReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.widget.Toast;
+
+/**
+ * Minimal DeviceAdminReceiver to allow suspending packages during focus mode.
+ */
+public class BrayDeviceAdminReceiver extends DeviceAdminReceiver {
+    @Override
+    public void onEnabled(Context context, Intent intent) {
+        Toast.makeText(context, "Bray device admin enabled", Toast.LENGTH_SHORT).show();
+    }
+
+    @Override
+    public void onDisabled(Context context, Intent intent) {
+        Toast.makeText(context, "Bray device admin disabled", Toast.LENGTH_SHORT).show();
+    }
+}

--- a/android/app/src/main/java/com/bray/watcher/BrayService.java
+++ b/android/app/src/main/java/com/bray/watcher/BrayService.java
@@ -1,0 +1,301 @@
+package com.bray.watcher;
+
+import android.app.ActivityManager;
+import android.app.AlertDialog;
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.app.Service;
+import android.app.usage.UsageStats;
+import android.app.usage.UsageStatsManager;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.os.Build;
+import android.os.Handler;
+import android.os.IBinder;
+import android.os.Looper;
+import android.view.WindowManager;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * BrayService is the always-on watchdog that keeps the user's Android device on task.
+ * <p>
+ * It aggressively monitors usage stats, keeps a non-dismissable foreground notification,
+ * and intervenes when distracting applications take over the foreground. The implementation
+ * mirrors the requested Codex prompt: persistent notification with quick actions, periodic
+ * focus telemetry, and an intervention dialog that can outright terminate the offending app.
+ */
+public class BrayService extends Service {
+    private static final int NOTIFICATION_ID = 666;
+    private static final String CHANNEL_ID = "BRAY_CHANNEL";
+    private static final long MONITOR_INTERVAL_MS = 60_000L;
+
+    private UsageStatsManager usageManager;
+    private NotificationManager notificationManager;
+    private ActivityManager activityManager;
+    private final Handler handler = new Handler(Looper.getMainLooper());
+    private final Map<String, Long> shameLog = new ConcurrentHashMap<>();
+    private Thread monitorThread;
+    private FocusMode focusMode;
+    private long lastRevenueCheck = 0L;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        usageManager = (UsageStatsManager) getSystemService(USAGE_STATS_SERVICE);
+        notificationManager = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
+        activityManager = (ActivityManager) getSystemService(ACTIVITY_SERVICE);
+        focusMode = new FocusMode(this);
+
+        createPersistentNotification();
+        startMonitoring();
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        if (intent != null && intent.getAction() != null) {
+            switch (intent.getAction()) {
+                case "FOCUS":
+                case "FOCUS_MODE":
+                    focusMode.enableFocus(90);
+                    break;
+                case "KILL":
+                    killDistractingApps();
+                    break;
+                default:
+                    break;
+            }
+        }
+        return START_STICKY;
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        if (monitorThread != null) {
+            monitorThread.interrupt();
+        }
+        handler.removeCallbacksAndMessages(null);
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+    private void createPersistentNotification() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationChannel channel = new NotificationChannel(
+                    CHANNEL_ID,
+                    "Bray Watcher",
+                    NotificationManager.IMPORTANCE_HIGH
+            );
+            channel.setDescription("Always watching");
+            notificationManager.createNotificationChannel(channel);
+        }
+
+        Notification.Builder builder = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
+                ? new Notification.Builder(this, CHANNEL_ID)
+                : new Notification.Builder(this);
+
+        PendingIntent focusIntent = PendingIntent.getService(
+                this,
+                0,
+                new Intent(this, BrayService.class).setAction("FOCUS"),
+                PendingIntent.FLAG_IMMUTABLE
+        );
+
+        PendingIntent killIntent = PendingIntent.getService(
+                this,
+                1,
+                new Intent(this, BrayService.class).setAction("KILL"),
+                PendingIntent.FLAG_IMMUTABLE
+        );
+
+        builder.setContentTitle("Bray Active")
+                .setContentText(buildStatusText())
+                .setSmallIcon(R.drawable.eye)
+                .setOngoing(true)
+                .addAction(new Notification.Action.Builder(
+                        R.drawable.focus,
+                        "FOCUS",
+                        focusIntent
+                ).build())
+                .addAction(new Notification.Action.Builder(
+                        R.drawable.kill,
+                        "KILL APPS",
+                        killIntent
+                ).build());
+
+        startForeground(NOTIFICATION_ID, builder.build());
+    }
+
+    private void startMonitoring() {
+        monitorThread = new Thread(() -> {
+            while (!Thread.currentThread().isInterrupted()) {
+                checkDistractingApps();
+                checkOB1Revenue();
+                updateNotification();
+                try {
+                    Thread.sleep(MONITOR_INTERVAL_MS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        }, "Bray-Monitor");
+        monitorThread.start();
+    }
+
+    private void checkDistractingApps() {
+        UsageStats current = getCurrentApp();
+        if (current == null) {
+            return;
+        }
+
+        String packageName = current.getPackageName();
+        if (getDistractingApps().contains(packageName)) {
+            showInterventionDialog(packageName);
+        }
+    }
+
+    private void showInterventionDialog(String packageName) {
+        handler.post(() -> {
+            AlertDialog alert = new AlertDialog.Builder(BrayService.this)
+                    .setTitle("STOP")
+                    .setMessage("You're wasting time on " + packageName + "\n\nOB1 made €" + getOB1Revenue() + " while you scrolled.")
+                    .setPositiveButton("Kill App", (dialog, which) -> killApp(packageName))
+                    .setNegativeButton("5 More Minutes", (dialog, which) -> logShame(packageName))
+                    .create();
+
+            if (alert.getWindow() != null) {
+                alert.getWindow().setType(WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY);
+            }
+            alert.show();
+        });
+    }
+
+    private void updateNotification() {
+        Notification.Builder builder = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
+                ? new Notification.Builder(this, CHANNEL_ID)
+                : new Notification.Builder(this);
+
+        PendingIntent focusIntent = PendingIntent.getService(
+                this,
+                0,
+                new Intent(this, BrayService.class).setAction("FOCUS"),
+                PendingIntent.FLAG_IMMUTABLE
+        );
+
+        PendingIntent killIntent = PendingIntent.getService(
+                this,
+                1,
+                new Intent(this, BrayService.class).setAction("KILL"),
+                PendingIntent.FLAG_IMMUTABLE
+        );
+
+        builder.setContentTitle("Bray Active")
+                .setContentText(buildStatusText())
+                .setSmallIcon(R.drawable.eye)
+                .setOngoing(true)
+                .addAction(new Notification.Action.Builder(
+                        R.drawable.focus,
+                        "FOCUS",
+                        focusIntent
+                ).build())
+                .addAction(new Notification.Action.Builder(
+                        R.drawable.kill,
+                        "KILL APPS",
+                        killIntent
+                ).build());
+
+        notificationManager.notify(NOTIFICATION_ID, builder.build());
+    }
+
+    private String buildStatusText() {
+        return "OB1: €" + getOB1Revenue() + " | Load: " + getCognitiveLoad() + "%";
+    }
+
+    private UsageStats getCurrentApp() {
+        if (usageManager == null) {
+            return null;
+        }
+        long end = System.currentTimeMillis();
+        long start = end - 5_000;
+        List<UsageStats> stats = usageManager.queryUsageStats(UsageStatsManager.INTERVAL_DAILY, start, end);
+        if (stats == null || stats.isEmpty()) {
+            return null;
+        }
+        UsageStats latest = null;
+        for (UsageStats usageStats : stats) {
+            if (latest == null || usageStats.getLastTimeUsed() > latest.getLastTimeUsed()) {
+                latest = usageStats;
+            }
+        }
+        return latest;
+    }
+
+    private void killDistractingApps() {
+        for (String packageName : getDistractingApps()) {
+            killApp(packageName);
+        }
+    }
+
+    private void killApp(String packageName) {
+        if (activityManager != null) {
+            activityManager.killBackgroundProcesses(packageName);
+        }
+    }
+
+    private void logShame(String packageName) {
+        shameLog.put(packageName, System.currentTimeMillis());
+        SharedPreferences prefs = getSharedPreferences("bray_shame", MODE_PRIVATE);
+        prefs.edit().putLong(packageName, System.currentTimeMillis()).apply();
+    }
+
+    private List<String> getDistractingApps() {
+        return Arrays.asList(
+                "com.instagram.android",
+                "com.twitter.android",
+                "com.reddit.frontpage",
+                "com.facebook.katana",
+                "com.zhiliaoapp.musically",
+                "com.google.android.youtube",
+                "com.slack.android",
+                "com.discord"
+        );
+    }
+
+    private int getOB1Revenue() {
+        SharedPreferences prefs = getSharedPreferences("bray_metrics", MODE_PRIVATE);
+        return prefs.getInt("ob1_revenue", 0);
+    }
+
+    private int getCognitiveLoad() {
+        SharedPreferences prefs = getSharedPreferences("bray_metrics", MODE_PRIVATE);
+        return prefs.getInt("cognitive_load", 45);
+    }
+
+    private void checkOB1Revenue() {
+        long now = System.currentTimeMillis();
+        if (now - lastRevenueCheck < 300_000L) {
+            return;
+        }
+        lastRevenueCheck = now;
+
+        SharedPreferences prefs = getSharedPreferences("bray_metrics", MODE_PRIVATE);
+        int currentRevenue = prefs.getInt("ob1_revenue", 0);
+        int shamePenalty = Math.min(shameLog.size() * 5, 50);
+        int adjustedRevenue = Math.max(0, currentRevenue - shamePenalty);
+        int cognitiveLoad = Math.min(100, prefs.getInt("cognitive_load", 45) + shameLog.size() * 3);
+
+        prefs.edit()
+                .putInt("ob1_revenue", adjustedRevenue)
+                .putInt("cognitive_load", cognitiveLoad)
+                .apply();
+    }
+}

--- a/android/app/src/main/java/com/bray/watcher/BrayTileService.java
+++ b/android/app/src/main/java/com/bray/watcher/BrayTileService.java
@@ -1,0 +1,53 @@
+package com.bray.watcher;
+
+import android.os.Build;
+import android.service.quicksettings.Tile;
+import android.service.quicksettings.TileService;
+
+import androidx.annotation.RequiresApi;
+
+/**
+ * Quick settings tile toggling Bray's focus mode.
+ */
+@RequiresApi(api = Build.VERSION_CODES.N)
+public class BrayTileService extends TileService {
+
+    @Override
+    public void onTileAdded() {
+        Tile tile = getQsTile();
+        if (tile != null) {
+            tile.setLabel("Bray");
+            tile.setContentDescription("Tap for focus mode");
+            tile.setState(Tile.STATE_INACTIVE);
+            tile.updateTile();
+        }
+    }
+
+    @Override
+    public void onClick() {
+        Tile tile = getQsTile();
+        if (tile == null) {
+            return;
+        }
+        if (tile.getState() == Tile.STATE_INACTIVE) {
+            startFocusMode();
+            tile.setState(Tile.STATE_ACTIVE);
+            tile.setLabel("FOCUS ON");
+        } else {
+            stopFocusMode();
+            tile.setState(Tile.STATE_INACTIVE);
+            tile.setLabel("Bray");
+        }
+        tile.updateTile();
+    }
+
+    private void startFocusMode() {
+        FocusMode focusMode = new FocusMode(this);
+        focusMode.enableFocus(90);
+    }
+
+    private void stopFocusMode() {
+        FocusMode focusMode = new FocusMode(this);
+        focusMode.disableFocus();
+    }
+}

--- a/android/app/src/main/java/com/bray/watcher/BrayWidget.kt
+++ b/android/app/src/main/java/com/bray/watcher/BrayWidget.kt
@@ -1,0 +1,53 @@
+package com.bray.watcher
+
+import android.app.PendingIntent
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProvider
+import android.content.Context
+import android.content.Intent
+import android.graphics.Color
+import android.widget.RemoteViews
+
+/**
+ * Home screen widget projecting the ruthless telemetry: OB1 revenue and cognitive load. The
+ * widget background shifts to red/orange/black depending on state and exposes a quick tap to
+ * trigger Bray's focus mode.
+ */
+class BrayWidget : AppWidgetProvider() {
+
+    override fun onUpdate(context: Context, appWidgetManager: AppWidgetManager, appWidgetIds: IntArray) {
+        for (id in appWidgetIds) {
+            updateWidget(context, appWidgetManager, id)
+        }
+    }
+
+    private fun updateWidget(context: Context, manager: AppWidgetManager, widgetId: Int) {
+        val prefs = context.getSharedPreferences("bray_metrics", Context.MODE_PRIVATE)
+        val revenue = prefs.getInt("ob1_revenue", 0)
+        val load = prefs.getInt("cognitive_load", 45)
+
+        val views = RemoteViews(context.packageName, R.layout.bray_widget).apply {
+            setTextViewText(R.id.widget_text, "OB1: €$revenue | Load: $load%")
+
+            val backgroundColor = when {
+                revenue == 0 -> Color.RED
+                load > 80 -> Color.parseColor("#FFA500")
+                else -> Color.BLACK
+            }
+            setInt(R.id.widget_layout, "setBackgroundColor", backgroundColor)
+
+            val focusIntent = Intent(context, BrayService::class.java).apply {
+                action = "FOCUS_MODE"
+            }
+            val pendingIntent = PendingIntent.getService(
+                context,
+                0,
+                focusIntent,
+                PendingIntent.FLAG_IMMUTABLE
+            )
+            setOnClickPendingIntent(R.id.focus_button, pendingIntent)
+        }
+
+        manager.updateAppWidget(widgetId, views)
+    }
+}

--- a/android/app/src/main/java/com/bray/watcher/FocusMode.java
+++ b/android/app/src/main/java/com/bray/watcher/FocusMode.java
@@ -1,0 +1,125 @@
+package com.bray.watcher;
+
+import android.app.ActivityManager;
+import android.app.NotificationManager;
+import android.app.admin.DevicePolicyManager;
+import android.content.ComponentName;
+import android.content.Context;
+import android.media.AudioManager;
+import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Implements an aggressive focus mode that mirrors the Codex prompt: enable DND, silence
+ * the ringer, kill background processes, and suspend distracting applications for the
+ * specified duration.
+ */
+public class FocusMode {
+    private final Context context;
+    private final AudioManager audioManager;
+    private final NotificationManager notificationManager;
+    private final ActivityManager activityManager;
+    private final DevicePolicyManager devicePolicyManager;
+    private final Handler handler = new Handler(Looper.getMainLooper());
+
+    public FocusMode(Context context) {
+        this.context = context.getApplicationContext();
+        this.audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+        this.notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+        this.activityManager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
+        this.devicePolicyManager = (DevicePolicyManager) context.getSystemService(Context.DEVICE_POLICY_SERVICE);
+    }
+
+    public void enableFocus(int minutes) {
+        if (notificationManager != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            notificationManager.setInterruptionFilter(NotificationManager.INTERRUPTION_FILTER_NONE);
+        }
+
+        if (audioManager != null) {
+            audioManager.setRingerMode(AudioManager.RINGER_MODE_SILENT);
+        }
+
+        killDistractingApps();
+        suspendDistractingApps();
+
+        handler.postDelayed(this::disableFocus, minutes * 60L * 1000L);
+    }
+
+    public void disableFocus() {
+        if (notificationManager != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            notificationManager.setInterruptionFilter(NotificationManager.INTERRUPTION_FILTER_ALL);
+        }
+
+        if (audioManager != null) {
+            audioManager.setRingerMode(AudioManager.RINGER_MODE_NORMAL);
+        }
+
+        unsuspendDistractingApps();
+    }
+
+    private List<String> getKillList() {
+        return Arrays.asList(
+                "com.instagram.android",
+                "com.twitter.android",
+                "com.reddit.frontpage",
+                "com.slack.android",
+                "com.discord",
+                "com.facebook.katana"
+        );
+    }
+
+    private void killDistractingApps() {
+        if (activityManager == null) {
+            return;
+        }
+        for (String packageName : getKillList()) {
+            activityManager.killBackgroundProcesses(packageName);
+        }
+    }
+
+    private void suspendDistractingApps() {
+        if (devicePolicyManager == null || !isDeviceAdmin()) {
+            return;
+        }
+        ComponentName admin = getAdminComponent();
+        if (admin == null) {
+            return;
+        }
+        for (String pkg : getKillList()) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                devicePolicyManager.setPackagesSuspended(admin, new String[]{pkg}, true);
+            }
+        }
+    }
+
+    private void unsuspendDistractingApps() {
+        if (devicePolicyManager == null || !isDeviceAdmin()) {
+            return;
+        }
+        ComponentName admin = getAdminComponent();
+        if (admin == null) {
+            return;
+        }
+        for (String pkg : getKillList()) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                devicePolicyManager.setPackagesSuspended(admin, new String[]{pkg}, false);
+            }
+        }
+    }
+
+    private boolean isDeviceAdmin() {
+        if (devicePolicyManager == null) {
+            return false;
+        }
+        ComponentName admin = getAdminComponent();
+        return admin != null && devicePolicyManager.isAdminActive(admin);
+    }
+
+    private ComponentName getAdminComponent() {
+        return new ComponentName(context, BrayDeviceAdminReceiver.class);
+    }
+}

--- a/android/app/src/main/res/drawable/eye.xml
+++ b/android/app/src/main/res/drawable/eye.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12,4C7,4 2.73,7.11 1,12c1.73,4.89 6,8 11,8s9.27,-3.11 11,-8C21.27,7.11 17,4 12,4zM12,17c-2.76,0 -5,-2.24 -5,-5s2.24,-5 5,-5 5,2.24 5,5 -2.24,5 -5,5zM12,9c-1.66,0 -3,1.34 -3,3s1.34,3 3,3 3,-1.34 3,-3 -1.34,-3 -3,-3z" />
+</vector>

--- a/android/app/src/main/res/drawable/focus.xml
+++ b/android/app/src/main/res/drawable/focus.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12,8a4,4 0 1,1 0,8 4,4 0 0,1 0,-8zm0,-6a1,1 0 0,1 1,1v2a1,1 0 0,1 -2,0V3a1,1 0 0,1 1,-1zm0,18a1,1 0 0,1 1,1v2a1,1 0 0,1 -2,0v-2a1,1 0 0,1 1,-1zM3,11h2a1,1 0 0,1 0,2H3a1,1 0 0,1 0,-2zm16,0h2a1,1 0 0,1 0,2h-2a1,1 0 0,1 0,-2z" />
+</vector>

--- a/android/app/src/main/res/drawable/kill.xml
+++ b/android/app/src/main/res/drawable/kill.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M3,6l9,12 9,-12H3zm9,9.75L5.85,7.5h14.3L12,15.75z" />
+</vector>

--- a/android/app/src/main/res/layout/bray_widget.xml
+++ b/android/app/src/main/res/layout/bray_widget.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/widget_layout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="#000000"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/widget_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="OB1: €0 | Load: 45%"
+        android:textColor="#FFFFFF"
+        android:textSize="16sp" />
+
+    <Button
+        android:id="@+id/focus_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="FOCUS" />
+</LinearLayout>

--- a/android/app/src/main/res/layout/shame_overlay.xml
+++ b/android/app/src/main/res/layout/shame_overlay.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="#CCFF0000"
+    android:orientation="vertical"
+    android:padding="24dp">
+
+    <TextView
+        android:id="@+id/shame_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="STOP."
+        android:textColor="#FFFFFF"
+        android:textSize="20sp"
+        android:textStyle="bold" />
+</LinearLayout>

--- a/android/app/src/main/res/xml/accessibility_service_config.xml
+++ b/android/app/src/main/res/xml/accessibility_service_config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
+    android:accessibilityEventTypes="typeWindowStateChanged"
+    android:accessibilityFeedbackType="feedbackGeneric"
+    android:notificationTimeout="100"
+    android:canPerformGestures="false"
+    android:accessibilityFlags="flagDefault"
+    android:description="Bray blocks distracting apps." />

--- a/android/app/src/main/res/xml/bray_widget_info.xml
+++ b/android/app/src/main/res/xml/bray_widget_info.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AppWidgetProvider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="200dp"
+    android:minHeight="100dp"
+    android:updatePeriodMillis="60000"
+    android:initialLayout="@layout/bray_widget" />

--- a/android/app/src/main/res/xml/device_admin.xml
+++ b/android/app/src/main/res/xml/device_admin.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<device-admin xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-policies>
+        <limit-password />
+        <watch-login />
+        <force-lock />
+        <wipe-data />
+    </uses-policies>
+</device-admin>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,0 +1,17 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath "com.android.tools.build:gradle:8.1.0"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.22"
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/android/proguard-rules.pro
+++ b/android/proguard-rules.pro
@@ -1,0 +1,1 @@
+# No-op placeholder

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = "Bray"
+include(":app")

--- a/poa/__init__.py
+++ b/poa/__init__.py
@@ -1,0 +1,5 @@
+"""Personal Operations Assistant package."""
+
+from .assistant import PersonalOpsAssistant
+
+__all__ = ["PersonalOpsAssistant"]

--- a/poa/__main__.py
+++ b/poa/__main__.py
@@ -1,0 +1,7 @@
+"""Enable `python -m poa` execution."""
+
+from .cli import main
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/poa/assistant.py
+++ b/poa/assistant.py
@@ -1,0 +1,322 @@
+"""Core logic for the Personal Operations Assistant."""
+
+from __future__ import annotations
+
+import random
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from . import storage
+from .config import PROJECTS
+
+
+@dataclass
+class Task:
+    """A lightweight representation of a stored task."""
+
+    id: int
+    description: str
+    category: str
+    stimulation: int
+    system_building: int
+    automation_potential: int
+    human_interaction: int
+    repetitive: bool
+    status: str
+
+    @property
+    def priority(self) -> int:
+        """Compute the priority using the brutalist algorithm."""
+
+        return (
+            self.stimulation * 3
+            + self.system_building * 2
+            + self.automation_potential * 2
+            - self.human_interaction * 5
+        )
+
+
+def _row_to_task(row) -> Task:
+    return Task(
+        id=row["id"],
+        description=row["description"],
+        category=row["category"],
+        stimulation=row["stimulation"],
+        system_building=row["system_building"],
+        automation_potential=row["automation_potential"],
+        human_interaction=row["human_interaction"],
+        repetitive=bool(row["repetitive"]),
+        status=row["status"],
+    )
+
+
+class PersonalOpsAssistant:
+    """Brain-dead honest assistant tuned for antisocial creatives."""
+
+    def __init__(self) -> None:
+        storage.setup_database()
+        storage.seed_defaults()
+
+    # ------------------------------------------------------------------
+    # Morning brief
+    # ------------------------------------------------------------------
+    def morning_brief(self) -> Dict[str, object]:
+        tasks = [_row_to_task(row) for row in storage.fetch_tasks()]
+        complex_task = next((task for task in tasks if task.priority >= 10), None)
+        if complex_task is None and tasks:
+            complex_task = tasks[0]
+
+        boring_task = next(
+            (task for task in tasks if task.category in {"boring", "maintenance"}),
+            None,
+        )
+        ignore_tasks = [
+            task
+            for task in tasks
+            if task.human_interaction >= 2 or task.priority <= 0
+        ][:3]
+
+        return {
+            "energy_focus": complex_task.description if complex_task else "Build anything worthwhile",
+            "boring": boring_task.description if boring_task else "None worth your time",
+            "ignore": [task.description for task in ignore_tasks] or ["Everything screaming for attention"],
+        }
+
+    # ------------------------------------------------------------------
+    # Task evaluation
+    # ------------------------------------------------------------------
+    def evaluate_task(self, description: str) -> Dict[str, object]:
+        metrics = self._score_description(description)
+        score = (
+            metrics["intellectual_stimulation"] * 3
+            + metrics["system_building"] * 2
+            + metrics["automation_potential"] * 2
+            - metrics["human_interaction"] * 5
+        )
+
+        reason_parts = []
+        if metrics["human_interaction"]:
+            reason_parts.append("High human interaction")
+        if not metrics["intellectual_stimulation"]:
+            reason_parts.append("Zero intellectual stimulation")
+        if metrics["repetition"]:
+            reason_parts.append("Repetitive nonsense")
+        if not reason_parts:
+            reason_parts.append("Finally something worthy")
+
+        alternative = self._suggest_alternative(description, metrics)
+
+        return {
+            "score": score,
+            "reason": ", ".join(reason_parts),
+            "alternative": alternative,
+        }
+
+    def _score_description(self, description: str) -> Dict[str, int]:
+        lowered = description.lower()
+        def flag(*keywords: str) -> int:
+            return 1 if any(word in lowered for word in keywords) else 0
+
+        metrics = {
+            "intellectual_stimulation": 0,
+            "system_building": 0,
+            "automation_potential": 0,
+            "human_interaction": 0,
+            "repetition": 0,
+        }
+
+        if flag("build", "design", "architect", "engine", "model", "algorithm"):
+            metrics["intellectual_stimulation"] = 2
+        if flag("research", "experiment", "novel"):
+            metrics["intellectual_stimulation"] = max(metrics["intellectual_stimulation"], 3)
+        if flag("optimize", "refactor", "system", "pipeline", "automation", "framework"):
+            metrics["system_building"] = 2
+        if flag("automate", "automation", "script", "template", "bot"):
+            metrics["automation_potential"] = 3
+        elif flag("repeat", "daily", "weekly", "boring", "manual"):
+            metrics["automation_potential"] = 2
+        if flag("email", "call", "meeting", "customer", "client", "interview", "conference"):
+            metrics["human_interaction"] = 3
+        elif flag("review", "feedback", "sync"):
+            metrics["human_interaction"] = 2
+        if flag("again", "follow up", "respond", "update", "report"):
+            metrics["repetition"] = 1
+
+        if metrics["intellectual_stimulation"] == 0 and flag("debug", "fix", "maintain"):
+            metrics["intellectual_stimulation"] = 1
+
+        if metrics["system_building"] == 0 and flag("build"):
+            metrics["system_building"] = 1
+
+        if metrics["automation_potential"] == 0 and metrics["repetition"]:
+            metrics["automation_potential"] = 2
+
+        return metrics
+
+    def _suggest_alternative(self, description: str, metrics: Dict[str, int]) -> str:
+        lowered = description.lower()
+        if metrics["human_interaction"] >= 2:
+            return "Automate the interaction – design a template or a bot and stop talking to humans"
+        if "document" in lowered or "doc" in lowered:
+            return "Record a loom, auto-transcribe, and ship docs without typing"
+        if metrics["repetition"]:
+            return "Spend 90 minutes scripting it once, save yourself forever"
+        return "Enhance the system – add a feedback loop or monitoring"
+
+    # ------------------------------------------------------------------
+    # Focus protector
+    # ------------------------------------------------------------------
+    def focus_protector(self) -> Dict[str, object]:
+        storage.add_focus_session(90, "Deep work initiated by focus protector")
+        storage.record_activity("focus_mode", {"duration": 90})
+        return {
+            "notifications": "All notifications muted (pretend they never existed)",
+            "status": "Slack/Discord set to 'Building. Response time: 48h'",
+            "timer": "90-minute deep work timer started",
+            "log": "Focus session logged for future bragging rights",
+        }
+
+    # ------------------------------------------------------------------
+    # Decision maker
+    # ------------------------------------------------------------------
+    def decide(self, question: str) -> Dict[str, object]:
+        lowered = question.lower()
+        networking = any(word in lowered for word in ["conference", "meet", "network", "event", "call"])
+        knowledge_gain = any(word in lowered for word in ["learn", "workshop", "course", "deep dive", "technical"])
+        logistics = any(word in lowered for word in ["travel", "flight", "hotel", "schedule"])
+        verdict = "Skip. Watch recordings at 2x speed instead."
+        if knowledge_gain and not networking:
+            verdict = "Attend only if recordings aren't available. Otherwise stream at 2x."
+        elif not networking and "buy" in lowered:
+            verdict = "Purchase if it accelerates automation. Otherwise pass."
+        friction = "HIGH" if networking else ("MEDIUM" if logistics else "LOW")
+        return {
+            "analysis": {
+                "networking_required": "HIGH" if networking else "LOW",
+                "new_knowledge": "HIGH" if knowledge_gain else "LOW",
+                "logistical_drag": friction,
+            },
+            "verdict": verdict,
+        }
+
+    # ------------------------------------------------------------------
+    # Energy tracker
+    # ------------------------------------------------------------------
+    def energy_tracker(self) -> Dict[str, object]:
+        now = datetime.now()
+        base = 80 if 8 <= now.hour <= 12 else 60
+        if now.hour >= 20 or now.hour <= 6:
+            base = 35
+        recent_sessions = storage.last_focus_session(within_hours=8)
+        if recent_sessions:
+            base -= 10
+        recent_energy = storage.fetch_recent_energy()
+        if recent_energy:
+            base = int((base + sum(row["level"] for row in recent_energy) / len(recent_energy)) / 2)
+        base = max(0, min(100, base))
+
+        if base < 30:
+            suggestion = "Stop pretending to work. Go walk."
+        elif base > 70:
+            suggestion = "Perfect time for a complex system build"
+        else:
+            suggestion = "Handle medium-intensity automation tasks"
+
+        storage.log_energy(base, suggestion)
+        return {
+            "level": base,
+            "suggestion": suggestion,
+        }
+
+    # ------------------------------------------------------------------
+    # Weekly reality check
+    # ------------------------------------------------------------------
+    def weekly_reality_check(self) -> Dict[str, object]:
+        planned = [_row_to_task(row) for row in storage.fetch_planned_tasks()]
+        planned_descriptions = [task.description for task in planned] or ["You planned nothing, congrats"]
+        actual = self._git_activity_last_week()
+        accuracy = self._calculate_accuracy(planned_descriptions, actual)
+        recommendation = (
+            "Stop planning, start building"
+            if accuracy < 50
+            else "Planning aligned with execution. Keep momentum"
+        )
+        return {
+            "planned": planned_descriptions,
+            "actual": actual,
+            "accuracy": accuracy,
+            "recommendation": recommendation,
+        }
+
+    def _git_activity_last_week(self) -> List[str]:
+        try:
+            output = subprocess.check_output(
+                [
+                    "git",
+                    "log",
+                    "--since=7.days",
+                    "--pretty=format:%h %s",
+                ],
+                cwd=Path.cwd(),
+                text=True,
+            )
+        except subprocess.CalledProcessError:
+            return ["No git history accessible"]
+        commits = [line.strip() for line in output.splitlines() if line.strip()]
+        return commits or ["No commits in the last 7 days"]
+
+    def _calculate_accuracy(self, planned: List[str], actual: List[str]) -> int:
+        if not planned:
+            return 0
+        matches = sum(1 for task in planned if any(task.lower() in entry.lower() for entry in actual))
+        return int((matches / len(planned)) * 100)
+
+    # ------------------------------------------------------------------
+    # OB1 integration
+    # ------------------------------------------------------------------
+    def ob1_focus(self) -> Dict[str, object]:
+        ob1_config = PROJECTS["ob1"]
+        priority_mode = ob1_config["priority_algorithm"]()
+        stimulating = list(ob1_config["stimulating_tasks"])
+        random.shuffle(stimulating)
+        return {
+            "mode": priority_mode,
+            "build": f"Automated {stimulating[0]} tracker (3h)",
+            "automate": "User onboarding so you never touch it again",
+            "ignore": "Feature requests from users with <€1000 MRR",
+            "reminder": "You're building a truth machine, not a friend maker.",
+        }
+
+    # ------------------------------------------------------------------
+    # Cognitive load manager
+    # ------------------------------------------------------------------
+    def cognitive_load_manager(self) -> Dict[str, object]:
+        loops = storage.fetch_open_loops()
+        auto_closed: List[str] = []
+        remaining: List[str] = []
+        for loop in loops:
+            description = loop["description"].lower()
+            if "follow up" in description:
+                storage.delete_open_loop(loop["id"])
+                auto_closed.append(f"{loop['description']} → Deleted (they'll chase you if it's real)")
+            elif any(keyword in description for keyword in ["maybe", "should", "consider"]):
+                storage.close_open_loop(loop["id"], "Moved to /dev/null")
+                auto_closed.append(f"{loop['description']} → Moved to /dev/null")
+            elif "network" in description:
+                storage.close_open_loop(loop["id"], "Number blocked")
+                auto_closed.append(f"{loop['description']} → Blocked number")
+            else:
+                remaining.append(loop["description"])
+
+        focus = remaining[0] if remaining else "OB1 prediction engine"
+        return {
+            "load": min(100, 20 + len(loops) * 5),
+            "open_loops": len(loops),
+            "auto_closed": auto_closed or ["Nothing disposable left"],
+            "remaining_focus": focus,
+            "mode": "Cave dwelling (no inputs, pure building)",
+        }
+

--- a/poa/cli.py
+++ b/poa/cli.py
@@ -1,0 +1,66 @@
+"""Command-line interface for the Personal Operations Assistant."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any, Dict
+
+from .assistant import PersonalOpsAssistant
+
+
+def _render(data: Dict[str, Any]) -> str:
+    return json.dumps(data, indent=2, ensure_ascii=False)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="poa",
+        description="Personal Operations Assistant – zero pleasantries, pure execution.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    subparsers.add_parser("morning", help="Deliver the brutal morning brief")
+
+    evaluate_parser = subparsers.add_parser("evaluate", help="Score a task against your brain chemistry")
+    evaluate_parser.add_argument("description", help="Task description to evaluate")
+
+    subparsers.add_parser("focus", help="Trigger the focus protector rituals")
+
+    decide_parser = subparsers.add_parser("decide", help="Make a low-stakes decision without emotion")
+    decide_parser.add_argument("question", help="Decision prompt")
+
+    subparsers.add_parser("energy", help="Check current energy and recommended usage")
+    subparsers.add_parser("weekly", help="Run the weekly reality check")
+    subparsers.add_parser("ob1", help="Get the OB1 focus briefing")
+    subparsers.add_parser("load", help="Engage the cognitive load manager")
+
+    args = parser.parse_args(argv)
+
+    assistant = PersonalOpsAssistant()
+    if args.command == "morning":
+        result = assistant.morning_brief()
+    elif args.command == "evaluate":
+        result = assistant.evaluate_task(args.description)
+    elif args.command == "focus":
+        result = assistant.focus_protector()
+    elif args.command == "decide":
+        result = assistant.decide(args.question)
+    elif args.command == "energy":
+        result = assistant.energy_tracker()
+    elif args.command == "weekly":
+        result = assistant.weekly_reality_check()
+    elif args.command == "ob1":
+        result = assistant.ob1_focus()
+    elif args.command == "load":
+        result = assistant.cognitive_load_manager()
+    else:
+        parser.error("Unknown command")
+        return 1
+
+    print(_render(result))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/poa/config.py
+++ b/poa/config.py
@@ -1,0 +1,139 @@
+"""Configuration and defaults for the Personal Operations Assistant."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from random import random
+from typing import Callable, Dict, List
+
+
+DATA_DIR = Path(__file__).resolve().parent / "data"
+DB_PATH = DATA_DIR / "poa.db"
+
+
+@dataclass
+class TaskTemplate:
+    """Default task template used to seed the database."""
+
+    description: str
+    category: str
+    stimulation: int
+    system_building: int
+    automation_potential: int
+    human_interaction: int
+    repetitive: bool = False
+    planned_for_week: bool = False
+
+
+DEFAULT_TASKS: List[TaskTemplate] = [
+    TaskTemplate(
+        description="Architect autonomous prediction engine",
+        category="build",
+        stimulation=3,
+        system_building=3,
+        automation_potential=2,
+        human_interaction=0,
+        planned_for_week=True,
+    ),
+    TaskTemplate(
+        description="Design experiment for controversy generator",
+        category="build",
+        stimulation=3,
+        system_building=2,
+        automation_potential=2,
+        human_interaction=0,
+        planned_for_week=True,
+    ),
+    TaskTemplate(
+        description="Implement durable deployment pipeline",
+        category="build",
+        stimulation=2,
+        system_building=3,
+        automation_potential=3,
+        human_interaction=0,
+    ),
+    TaskTemplate(
+        description="Answer legacy support tickets",
+        category="boring",
+        stimulation=0,
+        system_building=0,
+        automation_potential=1,
+        human_interaction=3,
+        repetitive=True,
+    ),
+    TaskTemplate(
+        description="Refactor knowledge base automation",
+        category="automation",
+        stimulation=2,
+        system_building=2,
+        automation_potential=3,
+        human_interaction=0,
+        planned_for_week=True,
+    ),
+    TaskTemplate(
+        description="Document internal API",
+        category="maintenance",
+        stimulation=1,
+        system_building=1,
+        automation_potential=1,
+        human_interaction=1,
+        repetitive=True,
+    ),
+    TaskTemplate(
+        description="Prototype load shedding daemon",
+        category="build",
+        stimulation=3,
+        system_building=3,
+        automation_potential=2,
+        human_interaction=0,
+    ),
+    TaskTemplate(
+        description="Evaluate user feature requests",
+        category="boring",
+        stimulation=0,
+        system_building=0,
+        automation_potential=1,
+        human_interaction=2,
+        repetitive=True,
+    ),
+]
+
+
+DEFAULT_OPEN_LOOPS = [
+    "Follow up with X about partnership",
+    "Maybe implement Y experimental widget",
+    "Should network with Z next month",
+    "Ping investor about vague idea",
+]
+
+
+PROJECTS: Dict[str, Dict[str, object]] = {
+    "ob1": {
+        "repo": "github.com/tuouser/ob1",
+        "priority_algorithm": lambda: "breakthrough" if random() > 0.7 else "maintain",
+        "boring_tasks": ["update docs", "respond to users", "fix UI"],
+        "stimulating_tasks": [
+            "new algorithm",
+            "prediction engine",
+            "controversy generator",
+        ],
+    }
+}
+
+
+def ensure_data_dir() -> None:
+    """Create the data directory if it does not exist."""
+
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+
+__all__ = [
+    "DATA_DIR",
+    "DB_PATH",
+    "DEFAULT_OPEN_LOOPS",
+    "DEFAULT_TASKS",
+    "PROJECTS",
+    "TaskTemplate",
+    "ensure_data_dir",
+]

--- a/poa/personality_context.md
+++ b/poa/personality_context.md
@@ -1,0 +1,18 @@
+# Personal Operations Assistant - Personality-Driven Task Management
+
+## User Profile (Peterson Big Five)
+- Extremely low agreeableness (8%): Skip social tasks, focus on systems
+- Low conscientiousness (25%): Need external structure for boring tasks
+- High openness (71%): Requires intellectual stimulation or dies inside
+- Low neuroticism (18%): No anxiety-driven urgency needed
+- Low extraversion (28%): Preserve energy, avoid group activities
+
+## Core Algorithm
+Priority = (Intellectual_Stimulation × 3) + (System_Building × 2) + (Automation_Potential × 2) - (Human_Interaction_Required × 5)
+
+## Daily Operations Rules
+1. NEVER suggest networking events, calls, or meetings
+2. Batch all human interactions into single "hell hour"
+3. Prioritize building over maintaining
+4. If task is repetitive, automate it instead
+5. Present 3 options max (decision fatigue is real)

--- a/poa/storage.py
+++ b/poa/storage.py
@@ -1,0 +1,289 @@
+"""SQLite-backed storage for the Personal Operations Assistant."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from contextlib import contextmanager
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Dict, Iterator, List, Optional
+
+from .config import DB_PATH, DEFAULT_OPEN_LOOPS, DEFAULT_TASKS, ensure_data_dir
+
+
+@contextmanager
+def get_connection(db_path: Path = DB_PATH) -> Iterator[sqlite3.Connection]:
+    """Yield a SQLite connection with foreign keys enabled."""
+
+    ensure_data_dir()
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    try:
+        yield conn
+    finally:
+        conn.commit()
+        conn.close()
+
+
+def setup_database(db_path: Path = DB_PATH) -> None:
+    """Initialize the database schema."""
+
+    with get_connection(db_path) as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS tasks (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                description TEXT NOT NULL,
+                category TEXT NOT NULL,
+                stimulation INTEGER NOT NULL,
+                system_building INTEGER NOT NULL,
+                automation_potential INTEGER NOT NULL,
+                human_interaction INTEGER NOT NULL,
+                repetitive INTEGER NOT NULL DEFAULT 0,
+                status TEXT NOT NULL DEFAULT 'pending',
+                planned_for_week INTEGER NOT NULL DEFAULT 0,
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        cursor.execute(
+            """
+            CREATE TRIGGER IF NOT EXISTS tasks_updated_at
+            AFTER UPDATE ON tasks
+            FOR EACH ROW
+            BEGIN
+                UPDATE tasks SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id;
+            END;
+            """
+        )
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS activity_log (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                event TEXT NOT NULL,
+                details TEXT,
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS focus_sessions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                started_at TEXT NOT NULL,
+                duration_minutes INTEGER NOT NULL,
+                summary TEXT
+            )
+            """
+        )
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS energy_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                level INTEGER NOT NULL,
+                note TEXT,
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS open_loops (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                description TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'open',
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+
+
+def seed_defaults(db_path: Path = DB_PATH) -> None:
+    """Seed the database with defaults if empty."""
+
+    with get_connection(db_path) as conn:
+        cursor = conn.cursor()
+        cursor.execute("SELECT COUNT(*) FROM tasks")
+        if cursor.fetchone()[0] == 0:
+            cursor.executemany(
+                """
+                INSERT INTO tasks (
+                    description,
+                    category,
+                    stimulation,
+                    system_building,
+                    automation_potential,
+                    human_interaction,
+                    repetitive,
+                    planned_for_week
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                [
+                    (
+                        task.description,
+                        task.category,
+                        task.stimulation,
+                        task.system_building,
+                        task.automation_potential,
+                        task.human_interaction,
+                        1 if task.repetitive else 0,
+                        1 if task.planned_for_week else 0,
+                    )
+                    for task in DEFAULT_TASKS
+                ],
+            )
+        cursor.execute("SELECT COUNT(*) FROM open_loops")
+        if cursor.fetchone()[0] == 0:
+            cursor.executemany(
+                "INSERT INTO open_loops (description) VALUES (?)",
+                [(loop,) for loop in DEFAULT_OPEN_LOOPS],
+            )
+
+
+def record_activity(event: str, details: Optional[Dict[str, object]] = None) -> None:
+    """Record an activity log entry."""
+
+    with get_connection() as conn:
+        conn.execute(
+            "INSERT INTO activity_log (event, details) VALUES (?, ?)",
+            (event, json.dumps(details or {})),
+        )
+
+
+def add_focus_session(duration_minutes: int, summary: str) -> None:
+    """Store a focus session record."""
+
+    with get_connection() as conn:
+        conn.execute(
+            "INSERT INTO focus_sessions (started_at, duration_minutes, summary) VALUES (?, ?, ?)",
+            (datetime.utcnow().isoformat(), duration_minutes, summary),
+        )
+
+
+def last_focus_session(within_hours: int = 24) -> Optional[sqlite3.Row]:
+    """Return the most recent focus session within the provided window."""
+
+    cutoff = datetime.utcnow() - timedelta(hours=within_hours)
+    with get_connection() as conn:
+        cursor = conn.execute(
+            "SELECT * FROM focus_sessions WHERE started_at >= ? ORDER BY started_at DESC LIMIT 1",
+            (cutoff.isoformat(),),
+        )
+        return cursor.fetchone()
+
+
+def log_energy(level: int, note: str) -> None:
+    """Insert an energy log entry."""
+
+    with get_connection() as conn:
+        conn.execute(
+            "INSERT INTO energy_events (level, note) VALUES (?, ?)",
+            (level, note),
+        )
+
+
+def fetch_recent_energy(hours: int = 6) -> List[sqlite3.Row]:
+    """Return recent energy events."""
+
+    cutoff = datetime.utcnow() - timedelta(hours=hours)
+    with get_connection() as conn:
+        cursor = conn.execute(
+            "SELECT * FROM energy_events WHERE created_at >= ? ORDER BY created_at DESC",
+            (cutoff.isoformat(),),
+        )
+        return list(cursor.fetchall())
+
+
+def fetch_tasks(order_by_priority: bool = True) -> List[sqlite3.Row]:
+    """Fetch tasks, optionally ordered by the priority algorithm."""
+
+    with get_connection() as conn:
+        cursor = conn.cursor()
+        if order_by_priority:
+            cursor.execute(
+                """
+                SELECT *, (
+                    stimulation * 3 +
+                    system_building * 2 +
+                    automation_potential * 2 -
+                    human_interaction * 5
+                ) AS priority
+                FROM tasks
+                ORDER BY priority DESC
+                """
+            )
+        else:
+            cursor.execute("SELECT * FROM tasks")
+        return list(cursor.fetchall())
+
+
+def fetch_planned_tasks() -> List[sqlite3.Row]:
+    """Return tasks flagged as planned for the week."""
+
+    with get_connection() as conn:
+        cursor = conn.execute("SELECT * FROM tasks WHERE planned_for_week = 1")
+        return list(cursor.fetchall())
+
+
+def fetch_open_loops() -> List[sqlite3.Row]:
+    """Return open loops that are still active."""
+
+    with get_connection() as conn:
+        cursor = conn.execute(
+            "SELECT * FROM open_loops WHERE status = 'open' ORDER BY created_at DESC"
+        )
+        return list(cursor.fetchall())
+
+
+def close_open_loop(loop_id: int, reason: str) -> None:
+    """Close an open loop with a blunt reason."""
+
+    with get_connection() as conn:
+        conn.execute(
+            "UPDATE open_loops SET status = ?, description = description || ' → ' || ? WHERE id = ?",
+            ("closed", reason, loop_id),
+        )
+
+
+def delete_open_loop(loop_id: int) -> None:
+    """Delete an open loop entirely."""
+
+    with get_connection() as conn:
+        conn.execute("DELETE FROM open_loops WHERE id = ?", (loop_id,))
+
+
+def reopen_open_loop(loop_id: int) -> None:
+    """Reopen a previously closed loop."""
+
+    with get_connection() as conn:
+        conn.execute("UPDATE open_loops SET status = 'open' WHERE id = ?", (loop_id,))
+
+
+def update_task_status(task_id: int, status: str) -> None:
+    """Update the status for a task."""
+
+    with get_connection() as conn:
+        conn.execute("UPDATE tasks SET status = ? WHERE id = ?", (status, task_id))
+
+
+__all__ = [
+    "add_focus_session",
+    "close_open_loop",
+    "delete_open_loop",
+    "fetch_open_loops",
+    "fetch_planned_tasks",
+    "fetch_recent_energy",
+    "fetch_tasks",
+    "get_connection",
+    "last_focus_session",
+    "log_energy",
+    "record_activity",
+    "reopen_open_loop",
+    "seed_defaults",
+    "setup_database",
+    "update_task_status",
+]


### PR DESCRIPTION
## Summary
- add an Android project skeleton for Bray with Gradle configuration and aggressive permissions
- implement the Bray foreground service, focus mode helper, and boot/device-admin receivers to kill and shame distracting apps
- deliver widget, accessibility service, quick settings tile, and resources that surface OB1 revenue and cognitive load telemetry

## Testing
- not run (Android tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d58c7eb840832193f18ff34845481e