### PR TITLE
ScoutPad (PWA mobile monetizzabile) + OpenScout (piattaforma scouting open-data)

### DIFF
--- a/.github/workflows/deploy-scoutpad.yml
+++ b/.github/workflows/deploy-scoutpad.yml
@@ -1,11 +1,13 @@
-# Pubblica ScoutPad su GitHub Pages a ogni push su main.
-# Prerequisito (una volta sola): Settings → Pages → Source: "GitHub Actions".
+# Pubblica ScoutPad come sito root su GitHub Pages (https://<utente>.github.io/<repo>/).
+#
+# NOTA: il repo usa già Pages in modalità "Deploy from a branch" (main), quindi
+# dopo il merge ScoutPad è subito online su /scoutpad/ SENZA questo workflow.
+# Usa questo workflow (avvio manuale) solo se vuoi ScoutPad alla radice dell'URL:
+# prima imposta Settings → Pages → Source: "GitHub Actions", poi lancialo da
+# Actions → "Deploy ScoutPad to GitHub Pages" → Run workflow.
 name: Deploy ScoutPad to GitHub Pages
 
 on:
-  push:
-    branches: [main]
-    paths: ['scoutpad/**']
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/deploy-scoutpad.yml
+++ b/.github/workflows/deploy-scoutpad.yml
@@ -1,0 +1,37 @@
+# Pubblica ScoutPad su GitHub Pages a ogni push su main.
+# Prerequisito (una volta sola): Settings → Pages → Source: "GitHub Actions".
+name: Deploy ScoutPad to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths: ['scoutpad/**']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+      - name: Prepare app files only (no tests/tools)
+        run: |
+          mkdir dist
+          cp scoutpad/index.html scoutpad/app.js scoutpad/sw.js scoutpad/manifest.webmanifest scoutpad/icon.svg dist/
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+> **Novità: [OpenScout](./openscout/README.md)** — piattaforma di scouting e match
+> analysis open-data con *Eligibility Intelligence* per qualsiasi federazione.
+> Generalizza Radar SMR e lo trasforma in un'alternativa a costo quasi zero a
+> Wyscout/InStat. Strategia di mercato in [openscout/STRATEGY.md](./openscout/STRATEGY.md).
+
 # Radar SMR - Agente RAG Autonomo per Calciatori Eleggibili
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/openscout/README.md
+++ b/openscout/README.md
@@ -1,0 +1,99 @@
+# OpenScout
+
+**Open-data scouting, match analysis & eligibility intelligence.**
+Zero npm dependencies · free professional event data · runs anywhere Node 18+ runs.
+
+OpenScout is a low-cost alternative to Wyscout/InStat built around a niche the
+incumbents don't serve: **national-team eligibility scouting** (oriundi /
+diaspora talent discovery) plus open-data analytics for federations, agents and
+semi-pro clubs. See [STRATEGY.md](./STRATEGY.md) for the market thesis.
+
+## Quick start
+
+```bash
+cd openscout
+
+# 1. See what's available for free (80+ competition-seasons of pro event data)
+node cli.js competitions
+
+# 2. Sync one (e.g. Euro 2024: competition 55, season 282)
+node cli.js sync 55 282
+
+# 3. Explore
+node cli.js players --pos FW            # ranked by OpenScout rating
+node cli.js player "Lamine Yamal"       # percentile profile
+node cli.js similar "Rodri"             # statistical doppelgängers
+node cli.js match list
+node cli.js match 3943043               # the Euro 2024 final
+node cli.js eligibility SMR             # San Marino diaspora screening
+
+# 4. Shareable single-file HTML reports
+node cli.js report player "Nico Williams" --o nico.html
+node cli.js report match 3943043 --o final.html
+
+# 5. Web UI + JSON API
+node cli.js serve --port 3030
+```
+
+No `npm install` needed — there are no dependencies.
+
+## What's inside
+
+| Module | What it does |
+|---|---|
+| `src/statsbomb.js` | fetch + disk cache for StatsBomb open data |
+| `src/metrics.js` | events → per-player metrics, per-90 rates, positional percentiles, OS rating |
+| `src/similarity.js` | z-scored cosine similarity ("find me another X") |
+| `src/match.js` | xG race, shot maps, pass networks, momentum, top performers |
+| `src/eligibility.js` | FIFA eligibility rules engine + diaspora screening per federation |
+| `src/federations.json` | citizenship-law knowledge base (SMR, MLT, FRO, LUX — extensible) |
+| `src/report.js` | self-contained HTML reports with SVG radar/pitch charts |
+| `src/server.js` | zero-dep HTTP server: web UI + JSON API |
+
+## JSON API
+
+```
+GET  /api/competitions          free competitions list
+GET  /api/datasets              synced datasets
+POST /api/sync?competition_id=55&season_id=282
+GET  /api/players?q=&group=FW&min_minutes=180
+GET  /api/player/:id            profile + percentiles + similar players
+GET  /api/matches
+GET  /api/match/:id             full match analysis
+GET  /api/federations
+GET  /api/eligibility/:CODE     diaspora screening
+POST /api/assess                {profile, federation} → FIFA eligibility assessment
+GET  /report/player/:id         HTML report
+GET  /report/match/:id          HTML report
+```
+
+## Eligibility assessment example
+
+```bash
+curl -X POST localhost:3030/api/assess -d '{
+  "federation": "MLT",
+  "profile": {
+    "name": "Example Player",
+    "birth_country": "Australia",
+    "citizenships": ["Australia"],
+    "grandparents_born_in": ["Malta"]
+  }
+}'
+# → status NOW_AFTER_PAPERWORK, grandparent path, citizenship claimable by descent
+```
+
+The screening layer flags candidates; the [Radar SMR](../README.md) RAG
+pipeline in this repo is the deep-dive layer that verifies ancestry from public
+sources.
+
+## Tests
+
+```bash
+npm test   # node:test, no dependencies
+```
+
+## Data credits
+
+Player/match data from the [StatsBomb open data](https://github.com/statsbomb/open-data)
+repository — free for research and non-commercial use under their terms. Always
+credit StatsBomb when publishing derived work.

--- a/openscout/STRATEGY.md
+++ b/openscout/STRATEGY.md
@@ -1,0 +1,90 @@
+# OpenScout — Strategia: la nicchia che Wyscout non può occupare
+
+## Il problema del mercato
+
+Wyscout, InStat/Hudl, StatsBomb e SkillCorner si contendono lo stesso cliente:
+il club professionistico con budget da €10.000–50.000/anno. Sotto quella soglia
+c'è un deserto: **federazioni minori, procuratori indipendenti, club semi-pro,
+direttori sportivi di Serie C/D, analisti freelance** — decine di migliaia di
+operatori che oggi lavorano con Excel, YouTube e passaparola.
+
+Competere frontalmente sui dati proprietari è impossibile (le aziende di event
+data hanno centinaia di taggatori). La mossa giusta non è "Wyscout più
+economico", è **cambiare l'asse della competizione**.
+
+## La nicchia nuova: Eligibility Intelligence
+
+Nessun incumbent risponde alla domanda: *"quali giocatori al mondo potrebbero
+vestire la maglia della mia nazionale?"*
+
+- Oltre 100 federazioni FIFA dipendono strutturalmente dagli oriundi
+  (San Marino, Malta, Lussemburgo, Faroe, Gibilterra, ma anche Filippine,
+  Indonesia, Giamaica, Marocco, Albania, Kosovo...).
+- La risposta richiede di incrociare **performance + genealogia + diritto della
+  cittadinanza + regolamento FIFA (RGAS art. 6–8)** — un problema di dati e
+  regole, non di video. Perfetto per software, terribile per gli incumbent
+  (fuori dal loro modello di business e dal loro cliente).
+- I clienti: federazioni (budget piccolo ma reale), procuratori che vogliono
+  "creare" un nazionale (il valore di mercato di un giocatore convocato sale),
+  e le stesse associazioni di oriundi.
+
+Questo repo aveva già il prototipo: **Radar SMR** (ricerca RAG di eleggibili
+per San Marino). OpenScout lo generalizza a qualsiasi federazione e ci
+costruisce attorno la piattaforma completa.
+
+## Architettura del prodotto (3 livelli)
+
+1. **Scouting & match analysis open-data** (gratis, acquisizione utenti)
+   — metriche per-90, percentili per ruolo, rating OS, similarity engine,
+   xG race, pass network, shot map, report HTML condivisibili.
+   Dati: StatsBomb open data oggi; FBref/Transfermarkt e tagging manuale domani.
+2. **Eligibility Intelligence** (il prodotto a pagamento)
+   — motore di regole FIFA + leggi di cittadinanza per federazione, screening
+   della diaspora sui dataset, shortlist "NOW / WHAT-IF".
+3. **Ancestry deep-dive** (servizio premium)
+   — la pipeline RAG di Radar SMR verifica genealogia e fonti sui nomi in
+   shortlist. Umano nel loop, margini alti, difendibilissimo.
+
+## Perché il costo è ~zero
+
+- **Zero dipendenze npm**: tutto Node standard library. Niente build, niente
+  supply chain, gira su qualsiasi Node 18+.
+- **Dati gratuiti**: StatsBomb open data (event data professionale: Mondiali,
+  Euro, Champions, Liga era-Messi, Bundesliga, calcio femminile...).
+- **Cache su disco**: ogni file scaricato una volta sola.
+- **Deploy**: un container da 256MB su Railway/Fly (free tier) o un VPS da €4.
+  I report sono HTML statici autosufficienti: condivisibili via WhatsApp,
+  pubblicabili su GitHub Pages.
+
+## Pricing proposto
+
+| Tier | Prezzo | Cosa include |
+|---|---|---|
+| Open | €0 | scouting open-data, report, self-host |
+| Scout | €29/mese | dataset propri (CSV/tagging), report white-label |
+| Federation | €490/anno | Eligibility Intelligence su misura, screening continuo |
+| Deep-dive | €a progetto | dossier genealogico-legale per giocatore |
+
+Wyscout parte da ~€5.000/anno per un singolo posto. Un'intera federazione
+piccola spende qui meno di un decimo.
+
+## Moat (perché non ti copiano)
+
+1. **Knowledge base regolatoria**: le regole di cittadinanza di 100+ paesi +
+   RGAS FIFA codificate e mantenute sono noiose da costruire — il vantaggio
+   si accumula.
+2. **Dati proprietari generati dagli utenti**: ogni deep-dive verificato
+   arricchisce un grafo genealogico-calcistico che nessun altro ha.
+3. **Community open-source** sul livello 1: distribuzione gratuita,
+   contributi gratuiti.
+4. Gli incumbent non possono seguirti senza cannibalizzare il proprio listino.
+
+## Roadmap
+
+- [x] MVP: ingestione open-data, metriche, percentili, rating, similarity,
+      match analysis, eligibility engine, report HTML, web UI, CLI
+- [ ] Import CSV/manuale per leghe non coperte (Serie D, NPL australiana...)
+- [ ] Knowledge base cittadinanza: da 4 a 50 federazioni
+- [ ] Integrazione diretta pipeline Radar SMR come worker "deep-dive"
+- [ ] Multi-utente + shortlist condivise (il momento del SaaS)
+- [ ] Video linking: timestamp evento → clip YouTube/Veo dei match amatoriali

--- a/openscout/cli.js
+++ b/openscout/cli.js
@@ -1,0 +1,250 @@
+#!/usr/bin/env node
+// OpenScout CLI — open-data scouting, match analysis & eligibility intelligence.
+import { writeFile } from 'node:fs/promises';
+import { getCompetitions, getEvents, getLineups } from './src/statsbomb.js';
+import { syncCompetition, loadAll, listDatasets } from './src/store.js';
+import { computePercentiles, positionGroup, primaryPosition, rating } from './src/metrics.js';
+import { similarPlayers } from './src/similarity.js';
+import { analyzeMatch } from './src/match.js';
+import { scanDataset, listFederations } from './src/eligibility.js';
+import { playerReportHTML, matchReportHTML } from './src/report.js';
+import { startServer } from './src/server.js';
+
+const [cmd, ...args] = process.argv.slice(2);
+
+const flag = (name, fallback) => {
+  const i = args.indexOf(`--${name}`);
+  return i >= 0 ? args[i + 1] : fallback;
+};
+
+// Positional args with `--flag value` pairs stripped out.
+const positionals = (list) => {
+  const out = [];
+  for (let i = 0; i < list.length; i++) {
+    if (list[i].startsWith('--')) { i += 1; continue; }
+    out.push(list[i]);
+  }
+  return out;
+};
+
+function table(rows, cols) {
+  const widths = cols.map((c) => Math.max(c.label.length, ...rows.map((r) => String(c.get(r)).length)));
+  console.log(cols.map((c, i) => c.label.padEnd(widths[i])).join('  '));
+  console.log(widths.map((w) => '-'.repeat(w)).join('  '));
+  for (const r of rows) console.log(cols.map((c, i) => String(c.get(r)).padEnd(widths[i])).join('  '));
+}
+
+async function findPlayer(players, query) {
+  const q = query.toLowerCase();
+  const hits = [...players.values()].filter(
+    (p) => p.name.toLowerCase().includes(q) || (p.fullName || '').toLowerCase().includes(q),
+  );
+  if (!hits.length) throw new Error(`No player matching '${query}'. Did you sync a competition? (openscout sync <comp> <season>)`);
+  hits.sort((a, b) => b.stats.minutes - a.stats.minutes);
+  return hits[0];
+}
+
+try {
+  switch (cmd) {
+    case 'competitions': {
+      const comps = await getCompetitions();
+      table(comps, [
+        { label: 'COMP', get: (c) => c.competition_id },
+        { label: 'SEASON', get: (c) => c.season_id },
+        { label: 'NAME', get: (c) => c.competition_name },
+        { label: 'YEAR', get: (c) => c.season_name },
+        { label: 'COUNTRY', get: (c) => c.country_name },
+        { label: 'GENDER', get: (c) => c.competition_gender },
+      ]);
+      console.log('\nSync one with: openscout sync <COMP> <SEASON>');
+      break;
+    }
+    case 'sync': {
+      const [comp, season] = args.map(Number);
+      if (!comp || !season) throw new Error('Usage: openscout sync <competition_id> <season_id>');
+      process.stdout.write(`Syncing competition ${comp}, season ${season}...\n`);
+      const r = await syncCompetition(comp, season, {
+        onProgress: (done, total) => process.stdout.write(`\r  matches ${done}/${total}`),
+      });
+      console.log(`\nDone: ${r.matches} matches (${r.failed} failed), ${r.players} players aggregated.`);
+      break;
+    }
+    case 'datasets': {
+      const ds = await listDatasets();
+      if (!ds.length) { console.log('No datasets synced yet. Run: openscout competitions'); break; }
+      table(ds, [
+        { label: 'COMP', get: (d) => d.competition_id },
+        { label: 'SEASON', get: (d) => d.season_id },
+        { label: 'NAME', get: (d) => `${d.competition} ${d.season}` },
+        { label: 'MATCHES', get: (d) => d.matches },
+        { label: 'PLAYERS', get: (d) => d.players },
+      ]);
+      break;
+    }
+    case 'players': {
+      const { players } = await loadAll();
+      const minMinutes = Number(flag('min-minutes', 180));
+      const group = flag('pos');
+      const pct = computePercentiles(players, { minMinutes });
+      let list = [...players.values()].filter((p) => p.stats.minutes >= minMinutes);
+      if (group) list = list.filter((p) => positionGroup(p) === group.toUpperCase());
+      const rows = list.map((p) => {
+        const c = pct.get(p.id);
+        return { p, c, os: c ? rating(c.percentiles, c.group) : 0 };
+      }).sort((a, b) => b.os - a.os).slice(0, Number(flag('limit', 25)));
+      table(rows, [
+        { label: 'OS', get: (r) => r.os },
+        { label: 'PLAYER', get: (r) => r.p.name },
+        { label: 'TEAM', get: (r) => r.p.team },
+        { label: 'POS', get: (r) => positionGroup(r.p) },
+        { label: 'MIN', get: (r) => Math.round(r.p.stats.minutes) },
+        { label: 'G', get: (r) => r.p.stats.goals },
+        { label: 'A', get: (r) => r.p.stats.assists },
+        { label: 'npxG/90', get: (r) => r.c.per90.npxg90.toFixed(2) },
+        { label: 'xA/90', get: (r) => r.c.per90.xa90.toFixed(2) },
+      ]);
+      break;
+    }
+    case 'player': {
+      const { players } = await loadAll();
+      const p = await findPlayer(players, positionals(args).join(' '));
+      const pct = computePercentiles(players);
+      const c = pct.get(p.id);
+      console.log(`\n${p.name} — ${p.team} — ${primaryPosition(p)} — ${p.country || '?'}`);
+      console.log(`Minutes: ${Math.round(p.stats.minutes)} | Matches: ${p.stats.matches} | Goals: ${p.stats.goals} | Assists: ${p.stats.assists}`);
+      if (c) {
+        console.log(`OpenScout rating: ${rating(c.percentiles, c.group)} (vs ${c.group} group)\n`);
+        const entries = Object.entries(c.percentiles).sort((a, b) => b[1] - a[1]);
+        for (const [k, v] of entries) {
+          const bar = '█'.repeat(Math.round(v / 4)).padEnd(25, '·');
+          console.log(`  ${k.padEnd(18)} ${bar} ${Math.round(v)}`);
+        }
+      } else {
+        console.log('(fewer than 180 minutes — percentiles unavailable)');
+      }
+      break;
+    }
+    case 'similar': {
+      const { players } = await loadAll();
+      const p = await findPlayer(players, positionals(args).join(' '));
+      console.log(`\nPlayers with a similar statistical profile to ${p.name} (${p.team}):\n`);
+      const sims = similarPlayers(p.id, players, { limit: Number(flag('limit', 10)) });
+      table(sims, [
+        { label: 'MATCH', get: (s) => `${(s.similarity * 100).toFixed(0)}%` },
+        { label: 'PLAYER', get: (s) => s.player.name },
+        { label: 'TEAM', get: (s) => s.player.team },
+        { label: 'POS', get: (s) => s.group },
+        { label: 'MIN', get: (s) => Math.round(s.player.stats.minutes) },
+      ]);
+      break;
+    }
+    case 'match': {
+      const { matches } = await loadAll();
+      if (!args[0] || args[0] === 'list') {
+        table(matches.slice(0, Number(flag('limit', 30))), [
+          { label: 'ID', get: (m) => m.match_id },
+          { label: 'DATE', get: (m) => m.date },
+          { label: 'MATCH', get: (m) => `${m.home} ${m.score} ${m.away}` },
+          { label: 'STAGE', get: (m) => m.stage || '' },
+        ]);
+        break;
+      }
+      const id = Number(args[0]);
+      const meta = matches.find((m) => m.match_id === id);
+      if (!meta) throw new Error(`Match ${id} not in synced datasets`);
+      const [events, lineups] = await Promise.all([getEvents(id), getLineups(id)]);
+      const info = {
+        match_id: id, match_date: meta.date,
+        home_team: { home_team_name: meta.home }, away_team: { away_team_name: meta.away },
+        home_score: meta.score.split('-')[0], away_score: meta.score.split('-')[1],
+        competition_stage: { name: meta.stage },
+      };
+      const a = analyzeMatch(info, events, lineups);
+      console.log(`\n${a.match.home} ${a.match.score} ${a.match.away} — xG ${a.xgRace[0].total} : ${a.xgRace[1].total}\n`);
+      console.log('Top performers:');
+      table(a.topPerformers, [
+        { label: 'SCORE', get: (p) => p.score },
+        { label: 'PLAYER', get: (p) => p.name },
+        { label: 'TEAM', get: (p) => p.team },
+      ]);
+      console.log(`\nFull visual report: openscout report match ${id}`);
+      break;
+    }
+    case 'eligibility': {
+      const fed = args[0];
+      if (!fed) {
+        console.log('Available federations:');
+        for (const f of listFederations()) console.log(`  ${f.code}  ${f.name}`);
+        console.log('\nUsage: openscout eligibility <CODE>');
+        break;
+      }
+      const { players } = await loadAll();
+      const scan = scanDataset(players, fed, { minMinutes: Number(flag('min-minutes', 90)) });
+      console.log(`\nEligibility screening for ${scan.federation}`);
+      console.log(`Diaspora pool: ${scan.diaspora_countries.join(', ')}`);
+      console.log(`${scan.notes}\n`);
+      table(scan.candidates.slice(0, Number(flag('limit', 25))), [
+        { label: 'PLAYER', get: (c) => c.name },
+        { label: 'NATIONALITY', get: (c) => c.nationality },
+        { label: 'TEAM', get: (c) => c.team },
+        { label: 'POS', get: (c) => c.position },
+        { label: 'MIN', get: (c) => c.minutes },
+        { label: 'npxG+xA/90', get: (c) => c.npxgPlusXa90 },
+      ]);
+      console.log('\nNext step: run the Radar SMR RAG deep-dive on shortlisted names to verify ancestry.');
+      break;
+    }
+    case 'report': {
+      const kind = args[0];
+      const out = flag('o');
+      const { players, matches } = await loadAll();
+      if (kind === 'player') {
+        const p = await findPlayer(players, positionals(args.slice(1)).join(' '));
+        const file = out || `report-${p.name.replace(/\W+/g, '-').toLowerCase()}.html`;
+        await writeFile(file, playerReportHTML(p.id, players));
+        console.log(`Report written: ${file}`);
+      } else if (kind === 'match') {
+        const id = Number(args[1]);
+        const meta = matches.find((m) => m.match_id === id);
+        if (!meta) throw new Error(`Match ${id} not in synced datasets`);
+        const [events, lineups] = await Promise.all([getEvents(id), getLineups(id)]);
+        const info = {
+          match_id: id, match_date: meta.date,
+          home_team: { home_team_name: meta.home }, away_team: { away_team_name: meta.away },
+          home_score: meta.score.split('-')[0], away_score: meta.score.split('-')[1],
+          competition_stage: { name: meta.stage },
+        };
+        const file = out || `report-match-${id}.html`;
+        await writeFile(file, matchReportHTML(analyzeMatch(info, events, lineups)));
+        console.log(`Report written: ${file}`);
+      } else {
+        throw new Error('Usage: openscout report player <name> | report match <id> [--o file.html]');
+      }
+      break;
+    }
+    case 'serve': {
+      const port = Number(flag('port', process.env.PORT || 3030));
+      await startServer({ port });
+      console.log(`OpenScout running at http://localhost:${port}`);
+      break;
+    }
+    default:
+      console.log(`OpenScout — open-data scouting & match analysis
+
+Usage:
+  openscout competitions                      list free competitions (StatsBomb open data)
+  openscout sync <comp_id> <season_id>        download & aggregate one competition
+  openscout datasets                          list synced datasets
+  openscout players [--pos FW] [--limit 25]   ranked player table
+  openscout player <name>                     player profile with percentiles
+  openscout similar <name>                    statistically similar players
+  openscout match [list | <id>]               match analysis
+  openscout eligibility [CODE]                national-team eligibility screening
+  openscout report player <name> [--o f.html] shareable HTML scouting report
+  openscout report match <id> [--o f.html]    shareable HTML match report
+  openscout serve [--port 3030]               web UI + JSON API`);
+  }
+} catch (err) {
+  console.error(`Error: ${err.message}`);
+  process.exit(1);
+}

--- a/openscout/package.json
+++ b/openscout/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "openscout",
+  "version": "0.1.0",
+  "description": "Open-data scouting & match analysis platform with eligibility intelligence. Zero dependencies.",
+  "type": "module",
+  "bin": {
+    "openscout": "./cli.js"
+  },
+  "scripts": {
+    "start": "node cli.js serve",
+    "test": "node --test"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "license": "MIT"
+}

--- a/openscout/src/eligibility.js
+++ b/openscout/src/eligibility.js
@@ -1,0 +1,134 @@
+// Eligibility Intelligence: which players could represent a national federation?
+//
+// Two layers:
+//  1. assess(profile, federation)  — rules engine applying FIFA eligibility
+//     paths (RGAS art. 6-8) + the federation's citizenship law to a researched
+//     player profile (ancestry, birthplace, residency). This generalizes the
+//     Radar SMR San Marino logic to any federation.
+//  2. scanDataset(players, federation) — fast screening of a synced open-data
+//     dataset: flags players whose nationality matches the federation's
+//     diaspora countries as ancestry-investigation candidates.
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { per90, positionGroup } from './metrics.js';
+
+const FEDERATIONS = JSON.parse(
+  readFileSync(path.join(path.dirname(fileURLToPath(import.meta.url)), 'federations.json'), 'utf8'),
+);
+
+export const listFederations = () =>
+  Object.entries(FEDERATIONS).map(([code, f]) => ({ code, name: f.name }));
+
+export const getFederation = (code) => {
+  const f = FEDERATIONS[code.toUpperCase()];
+  if (!f) throw new Error(`Unknown federation '${code}'. Available: ${Object.keys(FEDERATIONS).join(', ')}`);
+  return { code: code.toUpperCase(), ...f };
+};
+
+/**
+ * profile = {
+ *   name, birth_country, citizenships: [..],
+ *   parents_born_in: [..countries..], grandparents_born_in: [..],
+ *   residency: { country, years, years_after_18 },
+ *   caps_for_other_nation: { competitive: bool }
+ * }
+ */
+export function assess(profile, federationCode) {
+  const fed = getFederation(federationCode);
+  const target = fed.fifa_country;
+  const law = fed.citizenship_law;
+  const paths = [];
+  const has = (arr, c) => (arr || []).includes(c);
+  const hasCitizenship = has(profile.citizenships, target);
+
+  if (profile.caps_for_other_nation?.competitive) {
+    return {
+      federation: fed.name, player: profile.name, status: 'INELIGIBLE',
+      score: 0, paths: [],
+      summary: 'Already capped competitively for another senior national team (FIFA RGAS art. 8: switch not possible after competitive senior appearance, save for the one-time switch conditions).',
+    };
+  }
+
+  // FIFA territorial-link paths (a nationality/citizenship is always required on top)
+  if (profile.birth_country === target) {
+    paths.push({ type: 'birthplace', tier: 'NOW', detail: `Born in ${target}` });
+  }
+  if (has(profile.parents_born_in, target)) {
+    paths.push({ type: 'parent', tier: 'NOW', detail: `Biological parent born in ${target}` });
+  }
+  if (has(profile.grandparents_born_in, target)) {
+    paths.push({ type: 'grandparent', tier: 'NOW', detail: `Biological grandparent born in ${target}` });
+  }
+  const res = profile.residency;
+  if (res?.country === target) {
+    if ((res.years_after_18 ?? 0) >= 5) {
+      paths.push({ type: 'residency', tier: 'NOW', detail: '5+ years of residence after age 18 (FIFA art. 6.1d)' });
+    } else if ((res.years_after_18 ?? 0) > 0) {
+      const remaining = 5 - res.years_after_18;
+      paths.push({ type: 'residency', tier: 'WHAT_IF', detail: `Residency path: ~${remaining.toFixed(1)} more years needed after age 18` });
+    }
+  }
+
+  // Citizenship layer
+  let citizenship;
+  if (hasCitizenship) {
+    citizenship = { status: 'HELD', detail: `Already holds ${target} citizenship` };
+  } else {
+    const generationOk =
+      (has(profile.parents_born_in, target) && law.jus_sanguinis_generations >= 1) ||
+      (has(profile.grandparents_born_in, target) && law.jus_sanguinis_generations >= 2);
+    if (generationOk) {
+      citizenship = { status: 'CLAIMABLE', detail: `Citizenship claimable by descent (jus sanguinis, up to ${law.jus_sanguinis_generations} generation(s))` };
+    } else if (res?.country === target) {
+      const needed = law.naturalization_residency_years - (res.years ?? 0);
+      citizenship = {
+        status: needed <= 0 ? 'CLAIMABLE' : 'LONG_SHOT',
+        detail: needed <= 0
+          ? 'Naturalization residency requirement already met'
+          : `Naturalization needs ${needed} more year(s) of residence` + (law.dual_citizenship_allowed ? '' : ' and renouncing current citizenship'),
+      };
+    } else {
+      citizenship = { status: 'NONE', detail: 'No known citizenship route' };
+    }
+  }
+
+  const nowPaths = paths.filter((p) => p.tier === 'NOW');
+  let status, score;
+  if (nowPaths.length && citizenship.status === 'HELD') { status = 'NOW'; score = 95; }
+  else if (nowPaths.length && citizenship.status === 'CLAIMABLE') { status = 'NOW_AFTER_PAPERWORK'; score = 80; }
+  else if (paths.length && citizenship.status !== 'NONE') { status = 'WHAT_IF'; score = 55; }
+  else if (citizenship.status === 'CLAIMABLE' || citizenship.status === 'LONG_SHOT') { status = 'WHAT_IF'; score = 35; }
+  else { status = 'INELIGIBLE'; score = 5; }
+
+  return {
+    federation: fed.name, player: profile.name, status, score,
+    paths, citizenship,
+    summary: status === 'INELIGIBLE'
+      ? 'No FIFA territorial link or citizenship route found.'
+      : `${status}: ${nowPaths[0]?.detail || paths[0]?.detail || citizenship.detail}. ${citizenship.detail}.`,
+  };
+}
+
+// Screen a synced dataset: rank diaspora-nationality players as candidates for
+// an ancestry deep-dive (the Radar SMR RAG pipeline is the follow-up step).
+export function scanDataset(players, federationCode, { minMinutes = 90 } = {}) {
+  const fed = getFederation(federationCode);
+  const diaspora = new Set(fed.diaspora_countries);
+  const candidates = [];
+  for (const p of players.values()) {
+    if (p.stats.minutes < minMinutes || !p.country) continue;
+    if (p.country === fed.fifa_country) continue;
+    if (!diaspora.has(p.country)) continue;
+    const r = per90(p);
+    candidates.push({
+      id: p.id, name: p.name, team: p.team, nationality: p.country,
+      position: positionGroup(p), minutes: Math.round(p.stats.minutes),
+      npxgPlusXa90: +r.npxgPlusXa90.toFixed(2),
+      progActions90: +(r.progPasses90 + r.progCarries90).toFixed(1),
+      action: 'INVESTIGATE_ANCESTRY',
+    });
+  }
+  candidates.sort((a, b) => b.npxgPlusXa90 - a.npxgPlusXa90);
+  return { federation: fed.name, diaspora_countries: fed.diaspora_countries, notes: fed.scouting_notes, candidates };
+}

--- a/openscout/src/federations.json
+++ b/openscout/src/federations.json
@@ -1,0 +1,50 @@
+{
+  "SMR": {
+    "name": "San Marino",
+    "fifa_country": "San Marino",
+    "citizenship_law": {
+      "jus_sanguinis_generations": 1,
+      "naturalization_residency_years": 10,
+      "dual_citizenship_allowed": false,
+      "notes": "Naturalizzazione richiede 10 anni di residenza continuativa e rinuncia alla cittadinanza precedente (valutazione caso per caso)."
+    },
+    "diaspora_countries": ["Italy", "United States of America", "United States", "Argentina", "France"],
+    "scouting_notes": "Bacino principale: cognomi sammarinesi in Emilia-Romagna/Marche e diaspora in USA/Argentina."
+  },
+  "MLT": {
+    "name": "Malta",
+    "fifa_country": "Malta",
+    "citizenship_law": {
+      "jus_sanguinis_generations": 2,
+      "naturalization_residency_years": 5,
+      "dual_citizenship_allowed": true,
+      "notes": "Cittadinanza per discendenza fino ai nonni nati a Malta; doppia cittadinanza ammessa dal 2000."
+    },
+    "diaspora_countries": ["Australia", "United Kingdom", "England", "Canada", "United States of America", "United States"],
+    "scouting_notes": "Diaspora enorme in Australia (oltre 150k oriundi) e Regno Unito: leghe target A-League, EFL, NPL Australia."
+  },
+  "FRO": {
+    "name": "Faroe Islands",
+    "fifa_country": "Faroe Islands",
+    "citizenship_law": {
+      "jus_sanguinis_generations": 1,
+      "naturalization_residency_years": 9,
+      "dual_citizenship_allowed": true,
+      "notes": "Passaporto danese: l'eleggibilità FIFA richiede legame territoriale specifico con le Isole Faroe."
+    },
+    "diaspora_countries": ["Denmark", "Iceland", "Norway"],
+    "scouting_notes": "Faroesi di seconda generazione nelle giovanili danesi (Superliga academies)."
+  },
+  "LUX": {
+    "name": "Luxembourg",
+    "fifa_country": "Luxembourg",
+    "citizenship_law": {
+      "jus_sanguinis_generations": 2,
+      "naturalization_residency_years": 5,
+      "dual_citizenship_allowed": true,
+      "notes": "Legge 2008/2017: recupero cittadinanza per discendenti di lussemburghesi (anche emigrati pre-1900)."
+    },
+    "diaspora_countries": ["France", "Belgium", "Germany", "Portugal", "United States of America", "United States", "Brazil"],
+    "scouting_notes": "Forte comunità portoghese in Lussemburgo (naturalizzabili) e discendenti negli USA/Brasile."
+  }
+}

--- a/openscout/src/match.js
+++ b/openscout/src/match.js
@@ -1,0 +1,119 @@
+// Single-match analysis: xG race, shot maps, pass networks, momentum, top performers.
+
+export function analyzeMatch(matchInfo, events, lineups) {
+  const teams = [matchInfo.home_team.home_team_name, matchInfo.away_team.away_team_name];
+
+  const shots = events
+    .filter((e) => e.type.name === 'Shot')
+    .map((e) => ({
+      minute: e.minute, second: e.second, period: e.period,
+      team: e.team.name, player: e.player.name,
+      x: e.location?.[0], y: e.location?.[1],
+      xg: e.shot.statsbomb_xg || 0,
+      outcome: e.shot.outcome?.name,
+      penalty: e.shot.type?.name === 'Penalty',
+    }));
+
+  // Cumulative xG timeline per team
+  const xgRace = teams.map((team) => {
+    let cum = 0;
+    const points = [{ minute: 0, xg: 0 }];
+    for (const s of shots.filter((s) => s.team === team).sort((a, b) => a.minute - b.minute || a.second - b.second)) {
+      cum += s.xg;
+      points.push({ minute: s.minute + s.second / 60, xg: +cum.toFixed(3), goal: s.outcome === 'Goal', player: s.player });
+    }
+    return { team, total: +cum.toFixed(2), points };
+  });
+
+  // Pass network per team: average position + pass links among the starting XI.
+  const startersByTeam = new Map();
+  for (const e of events.filter((e) => e.type.name === 'Starting XI')) {
+    startersByTeam.set(e.team.name, new Set(e.tactics.lineup.map((l) => l.player.id)));
+  }
+  const passNetworks = teams.map((team) => {
+    const starters = startersByTeam.get(team) || new Set();
+    const nodes = new Map(); // id -> {name, x, y, n, passes}
+    const links = new Map(); // "a>b" -> count
+    for (const e of events) {
+      if (e.team?.name !== team || !e.player || !starters.has(e.player.id)) continue;
+      if (!e.location) continue;
+      if (e.type.name === 'Pass' || e.type.name === 'Ball Receipt*' || e.type.name === 'Carry') {
+        let node = nodes.get(e.player.id);
+        if (!node) { node = { id: e.player.id, name: e.player.name, sx: 0, sy: 0, n: 0, passes: 0 }; nodes.set(e.player.id, node); }
+        node.sx += e.location[0]; node.sy += e.location[1]; node.n += 1;
+      }
+      if (e.type.name === 'Pass' && !e.pass.outcome && e.pass.recipient && starters.has(e.pass.recipient.id)) {
+        const key = `${e.player.id}>${e.pass.recipient.id}`;
+        links.set(key, (links.get(key) || 0) + 1);
+        const node = nodes.get(e.player.id);
+        if (node) node.passes += 1;
+      }
+    }
+    return {
+      team,
+      nodes: [...nodes.values()].map((n) => ({ id: n.id, name: n.name, x: +(n.sx / n.n).toFixed(1), y: +(n.sy / n.n).toFixed(1), passes: n.passes })),
+      links: [...links.entries()]
+        .map(([k, count]) => { const [a, b] = k.split('>').map(Number); return { from: a, to: b, count }; })
+        .filter((l) => l.count >= 3),
+    };
+  });
+
+  // Momentum: 5-minute windows, danger-weighted territorial dominance.
+  const maxMinute = Math.ceil(events.reduce((m, e) => Math.max(m, e.minute), 90));
+  const windows = [];
+  for (let start = 0; start < maxMinute; start += 5) {
+    const w = { from: start, to: start + 5 };
+    const score = { [teams[0]]: 0, [teams[1]]: 0 };
+    for (const e of events) {
+      if (e.minute < start || e.minute >= start + 5 || !e.team) continue;
+      if (e.type.name === 'Shot') score[e.team.name] += 1 + (e.shot.statsbomb_xg || 0) * 8;
+      else if (e.type.name === 'Pass' && e.location?.[0] >= 80 && !e.pass.outcome) score[e.team.name] += 0.15;
+      else if (e.type.name === 'Carry' && e.carry?.end_location?.[0] >= 80) score[e.team.name] += 0.1;
+    }
+    w.value = +(score[teams[0]] - score[teams[1]]).toFixed(2); // + = home dominance
+    windows.push(w);
+  }
+
+  // Top performers: quick composite from match events.
+  const perf = new Map();
+  const bump = (e, pts) => {
+    if (!e.player) return;
+    const cur = perf.get(e.player.id) || { name: e.player.name, team: e.team.name, score: 0 };
+    cur.score += pts;
+    perf.set(e.player.id, cur);
+  };
+  for (const e of events) {
+    switch (e.type.name) {
+      case 'Shot':
+        bump(e, (e.shot.statsbomb_xg || 0) * 1.2 + (e.shot.outcome?.name === 'Goal' ? 0.8 : 0));
+        break;
+      case 'Pass':
+        if (e.pass.goal_assist) bump(e, 0.7);
+        else if (e.pass.shot_assist) bump(e, 0.25);
+        else if (!e.pass.outcome && e.location && e.pass.end_location && e.pass.end_location[0] - e.location[0] >= 10 && e.pass.end_location[0] >= 60) bump(e, 0.04);
+        break;
+      case 'Carry':
+        if (e.location && e.carry?.end_location && e.carry.end_location[0] - e.location[0] >= 10) bump(e, 0.04);
+        break;
+      case 'Dribble': if (e.dribble?.outcome?.name === 'Complete') bump(e, 0.1); break;
+      case 'Interception': bump(e, 0.08); break;
+      case 'Ball Recovery': if (!e.ball_recovery?.recovery_failure) bump(e, 0.04); break;
+      case 'Block': bump(e, 0.06); break;
+      case 'Duel': if (e.duel?.type?.name === 'Tackle' && /^(Won|Success)/.test(e.duel.outcome?.name || '')) bump(e, 0.08); break;
+      case 'Goal Keeper': if (e.goalkeeper?.type?.name === 'Shot Saved') bump(e, 0.3); break;
+    }
+  }
+  const topPerformers = [...perf.values()].sort((a, b) => b.score - a.score).slice(0, 8)
+    .map((p) => ({ ...p, score: +p.score.toFixed(2) }));
+
+  return {
+    match: {
+      id: matchInfo.match_id,
+      date: matchInfo.match_date,
+      home: teams[0], away: teams[1],
+      score: `${matchInfo.home_score}-${matchInfo.away_score}`,
+      stage: matchInfo.competition_stage?.name,
+    },
+    xgRace, shots, passNetworks, momentum: windows, topPerformers,
+  };
+}

--- a/openscout/src/metrics.js
+++ b/openscout/src/metrics.js
@@ -1,0 +1,278 @@
+// Turns raw StatsBomb events + lineups into per-player aggregated metrics.
+
+const POSITION_GROUPS = {
+  Goalkeeper: 'GK',
+  'Right Center Back': 'CB', 'Left Center Back': 'CB', 'Center Back': 'CB',
+  'Right Back': 'FB', 'Left Back': 'FB', 'Right Wing Back': 'FB', 'Left Wing Back': 'FB',
+  'Center Defensive Midfield': 'MF', 'Right Defensive Midfield': 'MF', 'Left Defensive Midfield': 'MF',
+  'Center Midfield': 'MF', 'Right Center Midfield': 'MF', 'Left Center Midfield': 'MF',
+  'Center Attacking Midfield': 'AM', 'Right Attacking Midfield': 'AM', 'Left Attacking Midfield': 'AM',
+  'Right Midfield': 'AM', 'Left Midfield': 'AM',
+  'Right Wing': 'AM', 'Left Wing': 'AM',
+  'Center Forward': 'FW', 'Right Center Forward': 'FW', 'Left Center Forward': 'FW',
+  'Secondary Striker': 'FW', Striker: 'FW',
+};
+
+export const GROUP_LABELS = {
+  GK: 'Goalkeeper', CB: 'Centre-back', FB: 'Full-back / Wing-back',
+  MF: 'Central / Defensive Midfield', AM: 'Attacking Mid / Winger', FW: 'Forward',
+};
+
+function parseClock(str) {
+  if (!str) return null;
+  const [m, s] = str.split(':').map(Number);
+  return m + s / 60;
+}
+
+// Minutes per player from lineup position stints. `matchEnd` (in minutes) caps
+// open-ended stints (to: null = on pitch at the final whistle).
+export function playerMinutes(lineups, matchEnd) {
+  const minutes = new Map();
+  for (const team of lineups) {
+    for (const p of team.lineup) {
+      let total = 0;
+      for (const stint of p.positions || []) {
+        const from = parseClock(stint.from) ?? 0;
+        const to = parseClock(stint.to) ?? matchEnd;
+        total += Math.max(0, to - from);
+      }
+      if (total > 0) minutes.set(p.player_id, total);
+    }
+  }
+  return minutes;
+}
+
+function blankStats() {
+  return {
+    minutes: 0, matches: 0, starts: 0,
+    goals: 0, npGoals: 0, xg: 0, npxg: 0, shots: 0, shotsOnTarget: 0,
+    assists: 0, xa: 0, keyPasses: 0,
+    passes: 0, passesCompleted: 0, progressivePasses: 0, passesIntoBox: 0, crosses: 0,
+    carries: 0, progressiveCarries: 0, carryDistance: 0, dribbles: 0, dribblesCompleted: 0,
+    pressures: 0, counterpressures: 0, tackles: 0, tacklesWon: 0,
+    interceptions: 0, recoveries: 0, blocks: 0, clearances: 0, aerialsWon: 0,
+    foulsWon: 0, foulsCommitted: 0, dispossessed: 0, miscontrols: 0,
+    yellowCards: 0, redCards: 0,
+    saves: 0, goalsConceded: 0, psxgFaced: 0,
+  };
+}
+
+const IN_BOX = ([x, y]) => x >= 102 && y >= 18 && y <= 62;
+
+// Aggregate one match's events into the players map keyed by player_id.
+export function aggregateMatch({ events, lineups }, players) {
+  const matchEnd = events.reduce((m, e) => Math.max(m, e.minute + e.second / 60), 90);
+  const minutes = playerMinutes(lineups, matchEnd);
+  const shotsById = new Map();
+  for (const e of events) if (e.type.name === 'Shot') shotsById.set(e.id, e);
+
+  const touch = (e) => {
+    const id = e.player?.id;
+    if (id == null) return null;
+    let p = players.get(id);
+    if (!p) {
+      p = { id, name: e.player.name, team: e.team?.name, positions: {}, country: null, stats: blankStats() };
+      players.set(id, p);
+    }
+    return p;
+  };
+
+  // Roster metadata: nickname, nationality, position stints, starts.
+  for (const team of lineups) {
+    for (const lp of team.lineup) {
+      const mins = minutes.get(lp.player_id);
+      if (!mins) continue;
+      let p = players.get(lp.player_id);
+      if (!p) {
+        p = { id: lp.player_id, name: lp.player_name, team: team.team_name, positions: {}, country: null, stats: blankStats() };
+        players.set(lp.player_id, p);
+      }
+      p.name = lp.player_nickname || lp.player_name;
+      p.fullName = lp.player_name;
+      p.team = team.team_name;
+      p.country = lp.country?.name || p.country;
+      p.stats.minutes += mins;
+      p.stats.matches += 1;
+      for (const stint of lp.positions || []) {
+        const from = parseClock(stint.from) ?? 0;
+        const to = parseClock(stint.to) ?? matchEnd;
+        p.positions[stint.position] = (p.positions[stint.position] || 0) + Math.max(0, to - from);
+        if (stint.start_reason === 'Starting XI') p.stats.starts += 1;
+      }
+      for (const card of lp.cards || []) {
+        if (/Yellow/.test(card.card_type)) p.stats.yellowCards += 1;
+        if (/Red/.test(card.card_type)) p.stats.redCards += 1;
+      }
+    }
+  }
+
+  for (const e of events) {
+    const p = touch(e);
+    if (!p) continue;
+    const s = p.stats;
+    switch (e.type.name) {
+      case 'Shot': {
+        const shot = e.shot;
+        const isPen = shot.type?.name === 'Penalty';
+        s.shots += 1;
+        s.xg += shot.statsbomb_xg || 0;
+        if (!isPen) s.npxg += shot.statsbomb_xg || 0;
+        const out = shot.outcome?.name;
+        if (out === 'Goal') { s.goals += 1; if (!isPen) s.npGoals += 1; }
+        if (out === 'Goal' || out === 'Saved' || out === 'Saved To Post') s.shotsOnTarget += 1;
+        break;
+      }
+      case 'Pass': {
+        const pass = e.pass;
+        if (['Throw-in', 'Corner', 'Free Kick', 'Goal Kick', 'Kick Off'].includes(pass.type?.name) && pass.type?.name === 'Throw-in') break;
+        s.passes += 1;
+        const completed = !pass.outcome;
+        if (completed) s.passesCompleted += 1;
+        if (pass.goal_assist) s.assists += 1;
+        if (pass.shot_assist || pass.goal_assist) {
+          s.keyPasses += 1;
+          const shot = shotsById.get(pass.assisted_shot_id);
+          if (shot) s.xa += shot.shot.statsbomb_xg || 0;
+        }
+        if (pass.cross) s.crosses += 1;
+        if (completed && e.location && pass.end_location) {
+          const gain = pass.end_location[0] - e.location[0];
+          if (gain >= 10 && pass.end_location[0] >= 60) s.progressivePasses += 1;
+          if (IN_BOX(pass.end_location) && !IN_BOX(e.location)) s.passesIntoBox += 1;
+        }
+        break;
+      }
+      case 'Carry': {
+        s.carries += 1;
+        if (e.location && e.carry?.end_location) {
+          const gain = e.carry.end_location[0] - e.location[0];
+          if (gain > 0) s.carryDistance += gain;
+          if (gain >= 10) s.progressiveCarries += 1;
+        }
+        break;
+      }
+      case 'Dribble':
+        s.dribbles += 1;
+        if (e.dribble?.outcome?.name === 'Complete') s.dribblesCompleted += 1;
+        break;
+      case 'Pressure':
+        s.pressures += 1;
+        if (e.counterpress) s.counterpressures += 1;
+        break;
+      case 'Duel': {
+        const dt = e.duel?.type?.name;
+        if (dt === 'Tackle') {
+          s.tackles += 1;
+          if (/^(Won|Success)/.test(e.duel.outcome?.name || '')) s.tacklesWon += 1;
+        }
+        if (dt === 'Aerial Lost') { /* lost aerial: no-op, wins counted via miscellaneous */ }
+        break;
+      }
+      case 'Interception':
+        if (/^(Won|Success)/.test(e.interception?.outcome?.name || '')) s.interceptions += 1;
+        break;
+      case 'Ball Recovery':
+        if (!e.ball_recovery?.recovery_failure) s.recoveries += 1;
+        break;
+      case 'Block': s.blocks += 1; break;
+      case 'Clearance':
+        s.clearances += 1;
+        if (e.clearance?.aerial_won) s.aerialsWon += 1;
+        break;
+      case 'Foul Won': s.foulsWon += 1; break;
+      case 'Foul Committed': s.foulsCommitted += 1; break;
+      case 'Dispossessed': s.dispossessed += 1; break;
+      case 'Miscontrol': s.miscontrols += 1; break;
+      case 'Goal Keeper': {
+        const gk = e.goalkeeper;
+        if (gk?.type?.name === 'Shot Saved' || gk?.type?.name === 'Penalty Saved') s.saves += 1;
+        if (gk?.type?.name === 'Goal Conceded') s.goalsConceded += 1;
+        break;
+      }
+      case 'Miscellaneous':
+        if (e.miscellaneous?.aerial_won) s.aerialsWon += 1;
+        break;
+    }
+  }
+}
+
+export function primaryPosition(p) {
+  let best = null, bestMin = -1;
+  for (const [pos, mins] of Object.entries(p.positions)) {
+    if (mins > bestMin) { best = pos; bestMin = mins; }
+  }
+  return best;
+}
+
+export function positionGroup(p) {
+  const pos = primaryPosition(p);
+  return POSITION_GROUPS[pos] || 'MF';
+}
+
+// Per-90 rates for every counting stat, plus ratios.
+export function per90(p) {
+  const m = p.stats.minutes;
+  const f = m > 0 ? 90 / m : 0;
+  const s = p.stats;
+  return {
+    goals90: s.goals * f, npGoals90: s.npGoals * f, xg90: s.xg * f, npxg90: s.npxg * f,
+    shots90: s.shots * f, assists90: s.assists * f, xa90: s.xa * f, keyPasses90: s.keyPasses * f,
+    passes90: s.passes * f, passPct: s.passes ? (s.passesCompleted / s.passes) * 100 : 0,
+    progPasses90: s.progressivePasses * f, passesIntoBox90: s.passesIntoBox * f, crosses90: s.crosses * f,
+    progCarries90: s.progressiveCarries * f, carryDistance90: s.carryDistance * f,
+    dribbles90: s.dribbles * f,
+    dribblePct: s.dribbles ? (s.dribblesCompleted / s.dribbles) * 100 : 0,
+    pressures90: s.pressures * f, tackles90: s.tackles * f, interceptions90: s.interceptions * f,
+    recoveries90: s.recoveries * f, blocks90: s.blocks * f, clearances90: s.clearances * f,
+    aerialsWon90: s.aerialsWon * f, foulsWon90: s.foulsWon * f,
+    npxgPlusXa90: (s.npxg + s.xa) * f,
+    saves90: s.saves * f,
+    savePct: (s.saves + s.goalsConceded) ? (s.saves / (s.saves + s.goalsConceded)) * 100 : 0,
+  };
+}
+
+// Percentile rank (0-100) of each per-90 metric within the player's position
+// group, among players with at least `minMinutes`.
+export function computePercentiles(players, { minMinutes = 180 } = {}) {
+  const qualified = [...players.values()].filter((p) => p.stats.minutes >= minMinutes);
+  const byGroup = new Map();
+  for (const p of qualified) {
+    const g = positionGroup(p);
+    if (!byGroup.has(g)) byGroup.set(g, []);
+    byGroup.get(g).push(p);
+  }
+  const result = new Map();
+  for (const [group, members] of byGroup) {
+    const rates = members.map((p) => ({ p, r: per90(p) }));
+    const keys = Object.keys(rates[0]?.r || {});
+    const sorted = {};
+    for (const k of keys) sorted[k] = rates.map((x) => x.r[k]).sort((a, b) => a - b);
+    for (const { p, r } of rates) {
+      const pct = {};
+      for (const k of keys) {
+        const arr = sorted[k];
+        let below = 0, equal = 0;
+        for (const v of arr) { if (v < r[k]) below += 1; else if (v === r[k]) equal += 1; }
+        pct[k] = arr.length > 1 ? ((below + equal / 2) / arr.length) * 100 : 50;
+      }
+      result.set(p.id, { group, per90: r, percentiles: pct });
+    }
+  }
+  return result;
+}
+
+// Headline 0-100 rating: average of the percentiles that matter for the role.
+const RATING_KEYS = {
+  GK: ['savePct', 'saves90', 'passPct'],
+  CB: ['passPct', 'progPasses90', 'interceptions90', 'blocks90', 'clearances90', 'aerialsWon90', 'tackles90'],
+  FB: ['progPasses90', 'progCarries90', 'crosses90', 'tackles90', 'interceptions90', 'xa90', 'pressures90'],
+  MF: ['passPct', 'progPasses90', 'progCarries90', 'recoveries90', 'tackles90', 'xa90', 'npxg90', 'pressures90'],
+  AM: ['npxg90', 'xa90', 'keyPasses90', 'dribbles90', 'progCarries90', 'passesIntoBox90', 'shots90'],
+  FW: ['npGoals90', 'npxg90', 'shots90', 'xa90', 'aerialsWon90', 'pressures90'],
+};
+
+export function rating(percentiles, group) {
+  const keys = RATING_KEYS[group] || RATING_KEYS.MF;
+  const vals = keys.map((k) => percentiles[k] ?? 50);
+  return Math.round(vals.reduce((a, b) => a + b, 0) / vals.length);
+}

--- a/openscout/src/report.js
+++ b/openscout/src/report.js
@@ -1,0 +1,193 @@
+// Self-contained HTML scouting reports: shareable single files, no external assets.
+import { per90, computePercentiles, positionGroup, primaryPosition, rating, GROUP_LABELS } from './metrics.js';
+import { similarPlayers } from './similarity.js';
+
+const CSS = `
+  :root { --bg:#0d1117; --card:#161b22; --line:#30363d; --fg:#e6edf3; --dim:#8b949e; --acc:#3fb950; --acc2:#58a6ff; }
+  * { box-sizing: border-box; }
+  body { font-family: -apple-system, 'Segoe UI', Roboto, sans-serif; background: var(--bg); color: var(--fg); margin: 0; padding: 32px 16px; }
+  .wrap { max-width: 880px; margin: 0 auto; }
+  .card { background: var(--card); border: 1px solid var(--line); border-radius: 12px; padding: 24px; margin-bottom: 16px; }
+  h1 { margin: 0 0 4px; font-size: 26px; } h2 { font-size: 15px; color: var(--dim); margin: 0 0 16px; text-transform: uppercase; letter-spacing: .08em; }
+  .sub { color: var(--dim); margin-bottom: 24px; }
+  .badge { display: inline-block; background: var(--acc); color: #04260f; font-weight: 700; border-radius: 8px; padding: 4px 12px; font-size: 22px; }
+  .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 12px; }
+  .stat { background: var(--bg); border: 1px solid var(--line); border-radius: 8px; padding: 10px 12px; }
+  .stat b { display: block; font-size: 20px; } .stat span { color: var(--dim); font-size: 12px; }
+  .bar { display: grid; grid-template-columns: 180px 1fr 48px; gap: 10px; align-items: center; margin: 6px 0; font-size: 13px; }
+  .bar .track { background: var(--bg); border-radius: 4px; height: 10px; overflow: hidden; }
+  .bar .fill { height: 100%; border-radius: 4px; }
+  table { width: 100%; border-collapse: collapse; font-size: 14px; }
+  td, th { padding: 8px 10px; border-bottom: 1px solid var(--line); text-align: left; }
+  th { color: var(--dim); font-weight: 600; font-size: 12px; text-transform: uppercase; }
+  .footer { color: var(--dim); font-size: 12px; text-align: center; margin-top: 24px; }
+`;
+
+const pctColor = (v) => (v >= 80 ? '#3fb950' : v >= 60 ? '#90c978' : v >= 40 ? '#d29922' : v >= 20 ? '#db6d28' : '#f85149');
+
+function radarSVG(labels, values, size = 360) {
+  const cx = size / 2, cy = size / 2, R = size / 2 - 56;
+  const n = labels.length;
+  const pt = (i, r) => {
+    const a = (Math.PI * 2 * i) / n - Math.PI / 2;
+    return [cx + r * Math.cos(a), cy + r * Math.sin(a)];
+  };
+  let rings = '';
+  for (const f of [0.25, 0.5, 0.75, 1]) {
+    rings += `<polygon points="${labels.map((_, i) => pt(i, R * f).join(',')).join(' ')}" fill="none" stroke="#30363d" stroke-width="1"/>`;
+  }
+  const axes = labels.map((_, i) => { const [x, y] = pt(i, R); return `<line x1="${cx}" y1="${cy}" x2="${x}" y2="${y}" stroke="#30363d"/>`; }).join('');
+  const poly = labels.map((_, i) => pt(i, (R * Math.max(values[i], 2)) / 100).join(',')).join(' ');
+  const texts = labels.map((l, i) => {
+    const [x, y] = pt(i, R + 28);
+    return `<text x="${x}" y="${y}" fill="#8b949e" font-size="11" text-anchor="middle" dominant-baseline="middle">${l} <tspan fill="#e6edf3" font-weight="bold">${Math.round(values[i])}</tspan></text>`;
+  }).join('');
+  return `<svg viewBox="0 0 ${size} ${size}" width="100%" style="max-width:${size}px;display:block;margin:0 auto" xmlns="http://www.w3.org/2000/svg">
+    ${rings}${axes}<polygon points="${poly}" fill="rgba(88,166,255,.25)" stroke="#58a6ff" stroke-width="2"/>${texts}</svg>`;
+}
+
+const RADAR_BY_GROUP = {
+  GK: [['Save %', 'savePct'], ['Saves/90', 'saves90'], ['Pass %', 'passPct'], ['Passes/90', 'passes90'], ['Recoveries', 'recoveries90'], ['Clearances', 'clearances90']],
+  CB: [['Pass %', 'passPct'], ['Prog. passes', 'progPasses90'], ['Interceptions', 'interceptions90'], ['Tackles', 'tackles90'], ['Blocks', 'blocks90'], ['Clearances', 'clearances90'], ['Aerials won', 'aerialsWon90'], ['Recoveries', 'recoveries90']],
+  FB: [['Prog. passes', 'progPasses90'], ['Prog. carries', 'progCarries90'], ['Crosses', 'crosses90'], ['xA', 'xa90'], ['Tackles', 'tackles90'], ['Interceptions', 'interceptions90'], ['Pressures', 'pressures90'], ['Pass %', 'passPct']],
+  MF: [['Pass %', 'passPct'], ['Prog. passes', 'progPasses90'], ['Prog. carries', 'progCarries90'], ['xA', 'xa90'], ['npxG', 'npxg90'], ['Recoveries', 'recoveries90'], ['Tackles', 'tackles90'], ['Pressures', 'pressures90']],
+  AM: [['npxG', 'npxg90'], ['xA', 'xa90'], ['Key passes', 'keyPasses90'], ['Dribbles', 'dribbles90'], ['Prog. carries', 'progCarries90'], ['Box passes', 'passesIntoBox90'], ['Shots', 'shots90'], ['Pressures', 'pressures90']],
+  FW: [['npGoals', 'npGoals90'], ['npxG', 'npxg90'], ['Shots', 'shots90'], ['xA', 'xa90'], ['Key passes', 'keyPasses90'], ['Dribbles', 'dribbles90'], ['Aerials won', 'aerialsWon90'], ['Pressures', 'pressures90']],
+};
+
+export function playerReportHTML(playerId, players, { minMinutes = 180 } = {}) {
+  const p = players.get(playerId);
+  if (!p) throw new Error(`Player ${playerId} not found`);
+  const percentiles = computePercentiles(players, { minMinutes });
+  const ctx = percentiles.get(playerId);
+  if (!ctx) throw new Error(`${p.name} has fewer than ${minMinutes} minutes — not enough sample for a report`);
+  const group = ctx.group;
+  const r = ctx.per90;
+  const os = rating(ctx.percentiles, group);
+  const radarSpec = RADAR_BY_GROUP[group] || RADAR_BY_GROUP.MF;
+  const radar = radarSVG(radarSpec.map(([l]) => l), radarSpec.map(([, k]) => ctx.percentiles[k] ?? 50));
+
+  const bars = Object.entries(ctx.percentiles)
+    .filter(([k]) => !['savePct', 'saves90'].includes(k) || group === 'GK')
+    .sort((a, b) => b[1] - a[1])
+    .map(([k, v]) => `<div class="bar"><span>${k}</span><div class="track"><div class="fill" style="width:${v}%;background:${pctColor(v)}"></div></div><b>${Math.round(v)}</b></div>`)
+    .join('');
+
+  const similar = similarPlayers(playerId, players, { minMinutes, limit: 6 })
+    .map((s) => `<tr><td>${s.player.name}</td><td>${s.player.team}</td><td>${s.group}</td><td>${(s.similarity * 100).toFixed(0)}%</td></tr>`)
+    .join('');
+
+  const keyStats = [
+    ['Minutes', Math.round(p.stats.minutes)], ['Matches', p.stats.matches],
+    ['Goals', p.stats.goals], ['Assists', p.stats.assists],
+    ['npxG/90', r.npxg90.toFixed(2)], ['xA/90', r.xa90.toFixed(2)],
+    ['Prog. passes/90', r.progPasses90.toFixed(1)], ['Pass %', `${r.passPct.toFixed(0)}%`],
+  ].map(([l, v]) => `<div class="stat"><b>${v}</b><span>${l}</span></div>`).join('');
+
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>${p.name} — OpenScout report</title><style>${CSS}</style></head><body><div class="wrap">
+<div class="card"><h1>${p.name} <span class="badge">OS ${os}</span></h1>
+<div class="sub">${p.team} · ${primaryPosition(p)} (${GROUP_LABELS[group]}) · ${p.country || ''}</div>
+<div class="grid">${keyStats}</div></div>
+<div class="card"><h2>Percentile radar vs ${GROUP_LABELS[group]}s (min. ${minMinutes}')</h2>${radar}</div>
+<div class="card"><h2>All percentiles</h2>${bars}</div>
+<div class="card"><h2>Similar players</h2><table><tr><th>Player</th><th>Team</th><th>Pos</th><th>Style match</th></tr>${similar}</table></div>
+<div class="footer">Generated by OpenScout · data: StatsBomb open data · ${new Date().toISOString().slice(0, 10)}</div>
+</div></body></html>`;
+}
+
+export function matchReportHTML(analysis) {
+  const { match, xgRace, shots, momentum, topPerformers, passNetworks } = analysis;
+  const W = 760, H = 280, maxMin = Math.max(95, ...xgRace.flatMap((t) => t.points.map((p) => p.minute)));
+  const maxXg = Math.max(0.5, ...xgRace.map((t) => t.total)) * 1.15;
+  const X = (m) => 40 + (m / maxMin) * (W - 60);
+  const Y = (v) => H - 30 - (v / maxXg) * (H - 50);
+  const colors = ['#58a6ff', '#f85149'];
+  let race = `<svg viewBox="0 0 ${W} ${H}" width="100%" xmlns="http://www.w3.org/2000/svg">`;
+  race += `<line x1="40" y1="${H - 30}" x2="${W - 20}" y2="${H - 30}" stroke="#30363d"/>`;
+  for (const m of [0, 15, 30, 45, 60, 75, 90]) race += `<text x="${X(m)}" y="${H - 12}" fill="#8b949e" font-size="11" text-anchor="middle">${m}'</text>`;
+  xgRace.forEach((t, i) => {
+    let d = '', prev = null;
+    for (const pt of t.points) {
+      if (!prev) d = `M ${X(pt.minute)} ${Y(pt.xg)}`;
+      else d += ` L ${X(pt.minute)} ${Y(prev.xg)} L ${X(pt.minute)} ${Y(pt.xg)}`;
+      prev = pt;
+    }
+    d += ` L ${X(maxMin)} ${Y(t.total)}`;
+    race += `<path d="${d}" fill="none" stroke="${colors[i]}" stroke-width="2.5"/>`;
+    for (const pt of t.points.filter((p) => p.goal)) {
+      race += `<circle cx="${X(pt.minute)}" cy="${Y(pt.xg)}" r="6" fill="${colors[i]}"/><title>${pt.player}</title>`;
+    }
+    race += `<text x="${W - 16}" y="${Y(t.total) + 4}" fill="${colors[i]}" font-size="12" text-anchor="end">${t.team} ${t.total}</text>`;
+  });
+  race += '</svg>';
+
+  // Momentum bars
+  const MW = 760, MH = 140, maxV = Math.max(1, ...momentum.map((w) => Math.abs(w.value)));
+  let mom = `<svg viewBox="0 0 ${MW} ${MH}" width="100%" xmlns="http://www.w3.org/2000/svg"><line x1="0" y1="${MH / 2}" x2="${MW}" y2="${MH / 2}" stroke="#30363d"/>`;
+  const bw = MW / momentum.length - 2;
+  momentum.forEach((w, i) => {
+    const h = (Math.abs(w.value) / maxV) * (MH / 2 - 8);
+    const up = w.value >= 0;
+    mom += `<rect x="${i * (bw + 2)}" y="${up ? MH / 2 - h : MH / 2}" width="${bw}" height="${h}" fill="${up ? colors[0] : colors[1]}" opacity=".85"><title>${w.from}'-${w.to}'</title></rect>`;
+  });
+  mom += '</svg>';
+
+  // Shot maps (attacking right, half pitch per team)
+  const shotMap = (team, color) => {
+    const SW = 360, SH = 246; // 60x80 StatsBomb half-pitch scaled x3
+    let svg = `<svg viewBox="0 0 ${SW} ${SH}" width="100%" style="max-width:${SW}px" xmlns="http://www.w3.org/2000/svg">`;
+    svg += `<rect x="0" y="3" width="${SW - 6}" height="${SH - 6}" fill="none" stroke="#30363d"/>`;
+    svg += `<rect x="${SW - 6 - 54}" y="${(SH - 132) / 2}" width="54" height="132" fill="none" stroke="#30363d"/>`;
+    svg += `<rect x="${SW - 6 - 18}" y="${(SH - 60) / 2}" width="18" height="60" fill="none" stroke="#30363d"/>`;
+    for (const s of shots.filter((s) => s.team === team && s.x != null)) {
+      const x = ((s.x - 60) / 60) * (SW - 6), y = (s.y / 80) * (SH - 6) + 3;
+      const r = 4 + Math.sqrt(s.xg) * 14;
+      svg += s.outcome === 'Goal'
+        ? `<circle cx="${x}" cy="${y}" r="${r}" fill="${color}" stroke="#fff" stroke-width="1.5"><title>${s.player} ${s.minute}' — GOAL (xG ${s.xg.toFixed(2)})</title></circle>`
+        : `<circle cx="${x}" cy="${y}" r="${r}" fill="${color}" opacity=".35"><title>${s.player} ${s.minute}' — ${s.outcome} (xG ${s.xg.toFixed(2)})</title></circle>`;
+    }
+    return svg + '</svg>';
+  };
+
+  // Pass networks (full pitch 120x80 scaled x4)
+  const network = (net, color) => {
+    const PW = 480, PH = 320;
+    let svg = `<svg viewBox="0 0 ${PW} ${PH}" width="100%" style="max-width:${PW}px" xmlns="http://www.w3.org/2000/svg">`;
+    svg += `<rect x="2" y="2" width="${PW - 4}" height="${PH - 4}" fill="none" stroke="#30363d"/><line x1="${PW / 2}" y1="2" x2="${PW / 2}" y2="${PH - 2}" stroke="#30363d"/>`;
+    const px = (x) => (x / 120) * (PW - 4) + 2, py = (y) => (y / 80) * (PH - 4) + 2;
+    const pos = new Map(net.nodes.map((n) => [n.id, n]));
+    for (const l of net.links) {
+      const a = pos.get(l.from), b = pos.get(l.to);
+      if (!a || !b) continue;
+      svg += `<line x1="${px(a.x)}" y1="${py(a.y)}" x2="${px(b.x)}" y2="${py(b.y)}" stroke="${color}" stroke-width="${Math.min(l.count / 2.5, 7)}" opacity=".3"/>`;
+    }
+    const maxP = Math.max(1, ...net.nodes.map((n) => n.passes));
+    for (const n of net.nodes) {
+      const r = 7 + (n.passes / maxP) * 11;
+      const last = n.name.split(' ').pop();
+      svg += `<circle cx="${px(n.x)}" cy="${py(n.y)}" r="${r}" fill="${color}"><title>${n.name} — ${n.passes} completed passes</title></circle>`;
+      svg += `<text x="${px(n.x)}" y="${py(n.y) - r - 4}" fill="#e6edf3" font-size="10" text-anchor="middle">${last}</text>`;
+    }
+    return svg + '</svg>';
+  };
+
+  const perfRows = topPerformers.map((p, i) =>
+    `<tr><td>${i + 1}</td><td>${p.name}</td><td>${p.team}</td><td>${p.score}</td></tr>`).join('');
+
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>${match.home} ${match.score} ${match.away} — OpenScout</title><style>${CSS}</style></head><body><div class="wrap">
+<div class="card"><h1>${match.home} ${match.score} ${match.away}</h1>
+<div class="sub">${match.date} · ${match.stage || ''} · xG ${xgRace[0].total} – ${xgRace[1].total}</div></div>
+<div class="card"><h2>xG race</h2>${race}</div>
+<div class="card"><h2>Momentum (5' windows — up: ${match.home}, down: ${match.away})</h2>${mom}</div>
+<div class="card"><h2>Shot maps</h2>
+<div style="display:grid;grid-template-columns:1fr 1fr;gap:16px"><div><div class="sub">${match.home}</div>${shotMap(match.home, colors[0])}</div>
+<div><div class="sub">${match.away}</div>${shotMap(match.away, colors[1])}</div></div></div>
+<div class="card"><h2>Pass networks (starting XI, links ≥3 passes)</h2>
+<div style="display:grid;grid-template-columns:1fr 1fr;gap:16px"><div><div class="sub">${match.home}</div>${network(passNetworks[0], colors[0])}</div>
+<div><div class="sub">${match.away}</div>${network(passNetworks[1], colors[1])}</div></div></div>
+<div class="card"><h2>Top performers (event-based composite)</h2><table><tr><th>#</th><th>Player</th><th>Team</th><th>Score</th></tr>${perfRows}</table></div>
+<div class="footer">Generated by OpenScout · data: StatsBomb open data</div>
+</div></body></html>`;
+}

--- a/openscout/src/server.js
+++ b/openscout/src/server.js
@@ -1,0 +1,142 @@
+// Zero-dependency HTTP server: JSON API + single-page web UI + HTML reports.
+import http from 'node:http';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { getCompetitions, getMatches, getEvents, getLineups } from './statsbomb.js';
+import { loadAll, listDatasets, syncCompetition } from './store.js';
+import { computePercentiles, per90, positionGroup, primaryPosition, rating } from './metrics.js';
+import { similarPlayers } from './similarity.js';
+import { analyzeMatch } from './match.js';
+import { listFederations, scanDataset, assess } from './eligibility.js';
+import { playerReportHTML, matchReportHTML } from './report.js';
+
+const WEB = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'web');
+
+export async function startServer({ port = 3030 } = {}) {
+  let cache = await loadAll(); // { players, matches }
+  const reload = async () => { cache = await loadAll(); };
+
+  const json = (res, code, body) => {
+    res.writeHead(code, { 'content-type': 'application/json' });
+    res.end(JSON.stringify(body));
+  };
+  const html = (res, body) => {
+    res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+    res.end(body);
+  };
+
+  const playerSummary = (p, ctx) => ({
+    id: p.id, name: p.name, team: p.team, country: p.country,
+    position: primaryPosition(p), group: ctx?.group || positionGroup(p),
+    minutes: Math.round(p.stats.minutes), matches: p.stats.matches,
+    goals: p.stats.goals, assists: p.stats.assists,
+    npxg90: ctx ? +ctx.per90.npxg90.toFixed(2) : null,
+    xa90: ctx ? +ctx.per90.xa90.toFixed(2) : null,
+    rating: ctx ? rating(ctx.percentiles, ctx.group) : null,
+  });
+
+  const server = http.createServer(async (req, res) => {
+    const url = new URL(req.url, `http://${req.headers.host}`);
+    const route = url.pathname;
+    try {
+      if (route === '/' || route === '/index.html') {
+        return html(res, await readFile(path.join(WEB, 'index.html'), 'utf8'));
+      }
+      if (route === '/api/competitions') {
+        const comps = await getCompetitions();
+        return json(res, 200, comps.map((c) => ({
+          competition_id: c.competition_id, season_id: c.season_id,
+          name: c.competition_name, season: c.season_name,
+          country: c.country_name, gender: c.competition_gender,
+        })));
+      }
+      if (route === '/api/datasets') return json(res, 200, await listDatasets());
+      if (route === '/api/sync' && req.method === 'POST') {
+        const comp = Number(url.searchParams.get('competition_id'));
+        const season = Number(url.searchParams.get('season_id'));
+        const result = await syncCompetition(comp, season);
+        await reload();
+        return json(res, 200, { ok: true, matches: result.matches, players: result.players, failed: result.failed });
+      }
+      if (route === '/api/players') {
+        const q = (url.searchParams.get('q') || '').toLowerCase();
+        const group = url.searchParams.get('group');
+        const minMinutes = Number(url.searchParams.get('min_minutes') || 180);
+        const percentiles = computePercentiles(cache.players, { minMinutes });
+        let list = [...cache.players.values()]
+          .filter((p) => p.stats.minutes >= minMinutes)
+          .map((p) => playerSummary(p, percentiles.get(p.id)));
+        if (q) list = list.filter((p) => p.name.toLowerCase().includes(q) || (p.team || '').toLowerCase().includes(q));
+        if (group) list = list.filter((p) => p.group === group);
+        list.sort((a, b) => (b.rating ?? 0) - (a.rating ?? 0));
+        return json(res, 200, list.slice(0, 300));
+      }
+      const playerMatch = route.match(/^\/api\/player\/(\d+)$/);
+      if (playerMatch) {
+        const id = Number(playerMatch[1]);
+        const p = cache.players.get(id);
+        if (!p) return json(res, 404, { error: 'player not found' });
+        const percentiles = computePercentiles(cache.players);
+        const ctx = percentiles.get(id);
+        return json(res, 200, {
+          ...playerSummary(p, ctx),
+          stats: p.stats, per90: ctx?.per90 || per90(p), percentiles: ctx?.percentiles || null,
+          similar: similarPlayers(id, cache.players, { limit: 8 }).map((s) => ({
+            id: s.player.id, name: s.player.name, team: s.player.team, group: s.group,
+            similarity: +(s.similarity * 100).toFixed(0),
+          })),
+        });
+      }
+      if (route === '/api/matches') return json(res, 200, cache.matches.slice(0, 400));
+      const matchMatch = route.match(/^\/api\/match\/(\d+)$/);
+      if (matchMatch) {
+        const id = Number(matchMatch[1]);
+        const meta = cache.matches.find((m) => m.match_id === id);
+        if (!meta) return json(res, 404, { error: 'match not in synced datasets' });
+        const [events, lineups] = await Promise.all([getEvents(id), getLineups(id)]);
+        const info = {
+          match_id: id, match_date: meta.date,
+          home_team: { home_team_name: meta.home }, away_team: { away_team_name: meta.away },
+          home_score: meta.score.split('-')[0], away_score: meta.score.split('-')[1],
+          competition_stage: { name: meta.stage },
+        };
+        return json(res, 200, analyzeMatch(info, events, lineups));
+      }
+      if (route === '/api/federations') return json(res, 200, listFederations());
+      const eligMatch = route.match(/^\/api\/eligibility\/(\w+)$/);
+      if (eligMatch) return json(res, 200, scanDataset(cache.players, eligMatch[1]));
+      if (route === '/api/assess' && req.method === 'POST') {
+        const body = await new Promise((resolve) => {
+          let data = '';
+          req.on('data', (c) => { data += c; });
+          req.on('end', () => resolve(data));
+        });
+        const { profile, federation } = JSON.parse(body);
+        return json(res, 200, assess(profile, federation));
+      }
+      const reportPlayer = route.match(/^\/report\/player\/(\d+)$/);
+      if (reportPlayer) return html(res, playerReportHTML(Number(reportPlayer[1]), cache.players));
+      const reportMatch = route.match(/^\/report\/match\/(\d+)$/);
+      if (reportMatch) {
+        const id = Number(reportMatch[1]);
+        const meta = cache.matches.find((m) => m.match_id === id);
+        if (!meta) return json(res, 404, { error: 'match not in synced datasets' });
+        const [events, lineups] = await Promise.all([getEvents(id), getLineups(id)]);
+        const info = {
+          match_id: id, match_date: meta.date,
+          home_team: { home_team_name: meta.home }, away_team: { away_team_name: meta.away },
+          home_score: meta.score.split('-')[0], away_score: meta.score.split('-')[1],
+          competition_stage: { name: meta.stage },
+        };
+        return html(res, matchReportHTML(analyzeMatch(info, events, lineups)));
+      }
+      json(res, 404, { error: 'not found' });
+    } catch (err) {
+      json(res, 500, { error: err.message });
+    }
+  });
+
+  await new Promise((resolve) => server.listen(port, resolve));
+  return server;
+}

--- a/openscout/src/similarity.js
+++ b/openscout/src/similarity.js
@@ -1,0 +1,43 @@
+// "Find me another X": cosine similarity over z-scored per-90 profiles.
+import { per90, positionGroup } from './metrics.js';
+
+const VECTOR_KEYS = [
+  'npxg90', 'xa90', 'shots90', 'keyPasses90', 'passes90', 'passPct',
+  'progPasses90', 'passesIntoBox90', 'crosses90', 'progCarries90', 'carryDistance90',
+  'dribbles90', 'pressures90', 'tackles90', 'interceptions90', 'recoveries90',
+  'blocks90', 'clearances90', 'aerialsWon90', 'foulsWon90',
+];
+
+export function similarPlayers(targetId, players, { minMinutes = 180, limit = 10, sameGroupOnly = false } = {}) {
+  const pool = [...players.values()].filter((p) => p.stats.minutes >= minMinutes);
+  const target = players.get(targetId);
+  if (!target) throw new Error(`Player ${targetId} not in dataset`);
+  if (!pool.some((p) => p.id === targetId)) pool.push(target);
+
+  const rates = pool.map((p) => ({ p, r: per90(p) }));
+  // z-score each dimension across the pool
+  const stats = VECTOR_KEYS.map((k) => {
+    const vals = rates.map((x) => x.r[k]);
+    const mean = vals.reduce((a, b) => a + b, 0) / vals.length;
+    const sd = Math.sqrt(vals.reduce((a, v) => a + (v - mean) ** 2, 0) / vals.length) || 1;
+    return { k, mean, sd };
+  });
+  const vectors = new Map(rates.map(({ p, r }) => [
+    p.id, stats.map(({ k, mean, sd }) => (r[k] - mean) / sd),
+  ]));
+
+  const tv = vectors.get(targetId);
+  const tGroup = positionGroup(target);
+  const scored = [];
+  for (const { p } of rates) {
+    if (p.id === targetId) continue;
+    if (sameGroupOnly && positionGroup(p) !== tGroup) continue;
+    const v = vectors.get(p.id);
+    let dot = 0, na = 0, nb = 0;
+    for (let i = 0; i < tv.length; i++) { dot += tv[i] * v[i]; na += tv[i] ** 2; nb += v[i] ** 2; }
+    const sim = dot / (Math.sqrt(na) * Math.sqrt(nb) || 1);
+    scored.push({ player: p, similarity: sim, group: positionGroup(p) });
+  }
+  scored.sort((a, b) => b.similarity - a.similarity);
+  return scored.slice(0, limit);
+}

--- a/openscout/src/statsbomb.js
+++ b/openscout/src/statsbomb.js
@@ -1,0 +1,50 @@
+// Fetch + cache layer for the StatsBomb open-data repository.
+// All responses are cached on disk so repeated runs cost zero bandwidth.
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const BASE = 'https://raw.githubusercontent.com/statsbomb/open-data/master/data';
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'data', 'cache');
+
+async function fetchJSON(relPath, { force = false } = {}) {
+  const cacheFile = path.join(ROOT, relPath);
+  if (!force && existsSync(cacheFile)) {
+    return JSON.parse(await readFile(cacheFile, 'utf8'));
+  }
+  const res = await fetch(`${BASE}/${relPath}`);
+  if (!res.ok) throw new Error(`StatsBomb fetch failed (${res.status}): ${relPath}`);
+  const text = await res.text();
+  await mkdir(path.dirname(cacheFile), { recursive: true });
+  await writeFile(cacheFile, text);
+  return JSON.parse(text);
+}
+
+export const getCompetitions = (opts) => fetchJSON('competitions.json', opts);
+export const getMatches = (competitionId, seasonId, opts) =>
+  fetchJSON(`matches/${competitionId}/${seasonId}.json`, opts);
+export const getLineups = (matchId, opts) => fetchJSON(`lineups/${matchId}.json`, opts);
+export const getEvents = (matchId, opts) => fetchJSON(`events/${matchId}.json`, opts);
+
+// Fetch many matches with bounded concurrency; onProgress(done, total) is optional.
+export async function fetchMatchData(matchIds, { concurrency = 6, onProgress } = {}) {
+  const results = new Map();
+  let done = 0;
+  const queue = [...matchIds];
+  async function worker() {
+    while (queue.length) {
+      const id = queue.shift();
+      try {
+        const [events, lineups] = await Promise.all([getEvents(id), getLineups(id)]);
+        results.set(id, { events, lineups });
+      } catch (err) {
+        results.set(id, { error: err.message });
+      }
+      done += 1;
+      onProgress?.(done, matchIds.length);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(concurrency, matchIds.length) }, worker));
+  return results;
+}

--- a/openscout/src/store.js
+++ b/openscout/src/store.js
@@ -1,0 +1,78 @@
+// Dataset persistence: synced competitions are aggregated once and saved as
+// compact JSON so the app starts instantly without re-parsing event files.
+import { mkdir, readFile, writeFile, readdir } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { getMatches, fetchMatchData } from './statsbomb.js';
+import { aggregateMatch } from './metrics.js';
+
+const DATASETS = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'data', 'datasets');
+
+export async function syncCompetition(competitionId, seasonId, { onProgress } = {}) {
+  const matches = await getMatches(competitionId, seasonId);
+  const ids = matches.map((m) => m.match_id);
+  const players = new Map();
+  const data = await fetchMatchData(ids, { onProgress });
+  let failed = 0;
+  for (const id of ids) {
+    const d = data.get(id);
+    if (!d || d.error) { failed += 1; continue; }
+    aggregateMatch(d, players);
+  }
+  const meta = matches[0] || {};
+  const dataset = {
+    competition_id: competitionId,
+    season_id: seasonId,
+    competition: meta.competition?.competition_name,
+    season: meta.season?.season_name,
+    synced_at: new Date().toISOString(),
+    matches: matches.map((m) => ({
+      match_id: m.match_id, date: m.match_date,
+      home: m.home_team.home_team_name, away: m.away_team.away_team_name,
+      score: `${m.home_score}-${m.away_score}`, stage: m.competition_stage?.name,
+    })),
+    players: [...players.values()],
+  };
+  await mkdir(DATASETS, { recursive: true });
+  await writeFile(path.join(DATASETS, `${competitionId}-${seasonId}.json`), JSON.stringify(dataset));
+  return { matches: matches.length, failed, players: players.size, dataset };
+}
+
+export async function listDatasets() {
+  if (!existsSync(DATASETS)) return [];
+  const files = (await readdir(DATASETS)).filter((f) => f.endsWith('.json'));
+  const out = [];
+  for (const f of files) {
+    const d = JSON.parse(await readFile(path.join(DATASETS, f), 'utf8'));
+    out.push({
+      competition_id: d.competition_id, season_id: d.season_id,
+      competition: d.competition, season: d.season,
+      matches: d.matches.length, players: d.players.length, synced_at: d.synced_at,
+    });
+  }
+  return out;
+}
+
+// Merge every synced dataset into one players Map (stats summed across
+// competitions) plus a global match index.
+export async function loadAll() {
+  const players = new Map();
+  const matches = [];
+  if (!existsSync(DATASETS)) return { players, matches };
+  const files = (await readdir(DATASETS)).filter((f) => f.endsWith('.json'));
+  for (const f of files) {
+    const d = JSON.parse(await readFile(path.join(DATASETS, f), 'utf8'));
+    for (const m of d.matches) matches.push({ ...m, competition: d.competition, season: d.season });
+    for (const p of d.players) {
+      const existing = players.get(p.id);
+      if (!existing) { players.set(p.id, structuredClone(p)); continue; }
+      for (const [k, v] of Object.entries(p.stats)) existing.stats[k] += v;
+      for (const [pos, mins] of Object.entries(p.positions)) {
+        existing.positions[pos] = (existing.positions[pos] || 0) + mins;
+      }
+    }
+  }
+  matches.sort((a, b) => (a.date < b.date ? 1 : -1));
+  return { players, matches };
+}

--- a/openscout/test/core.test.js
+++ b/openscout/test/core.test.js
@@ -1,0 +1,103 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { aggregateMatch, per90, computePercentiles, playerMinutes, positionGroup } from '../src/metrics.js';
+import { similarPlayers } from '../src/similarity.js';
+import { assess } from '../src/eligibility.js';
+
+const P1 = { id: 1, name: 'Striker One' };
+const P2 = { id: 2, name: 'Mid Two' };
+const TEAM = { id: 10, name: 'Test FC' };
+
+function fixtureLineups() {
+  const stint = (pos) => [{ position: pos, from: '00:00', to: null, from_period: 1, to_period: 2, start_reason: 'Starting XI', end_reason: 'Final Whistle' }];
+  return [{
+    team_id: 10, team_name: 'Test FC',
+    lineup: [
+      { player_id: 1, player_name: 'Striker One', country: { name: 'Italy' }, cards: [], positions: stint('Center Forward') },
+      { player_id: 2, player_name: 'Mid Two', country: { name: 'France' }, cards: [], positions: stint('Center Midfield') },
+    ],
+  }];
+}
+
+function fixtureEvents() {
+  return [
+    { id: 'p1', type: { name: 'Pass' }, minute: 10, second: 0, player: P2, team: TEAM,
+      location: [50, 40], pass: { end_location: [80, 40], shot_assist: true, assisted_shot_id: 's1' } },
+    { id: 's1', type: { name: 'Shot' }, minute: 10, second: 5, player: P1, team: TEAM,
+      location: [110, 40], shot: { statsbomb_xg: 0.4, outcome: { name: 'Goal' } } },
+    { id: 's2', type: { name: 'Shot' }, minute: 40, second: 0, player: P1, team: TEAM,
+      location: [105, 35], shot: { statsbomb_xg: 0.1, outcome: { name: 'Off T' } } },
+    { id: 'c1', type: { name: 'Carry' }, minute: 60, second: 0, player: P2, team: TEAM,
+      location: [40, 40], carry: { end_location: [65, 40] } },
+    { id: 'e', type: { name: 'Half End' }, minute: 90, second: 0 },
+  ];
+}
+
+test('playerMinutes handles open-ended stints', () => {
+  const minutes = playerMinutes(fixtureLineups(), 90);
+  assert.equal(minutes.get(1), 90);
+  assert.equal(minutes.get(2), 90);
+});
+
+test('aggregateMatch counts goals, xG, xA and progressive actions', () => {
+  const players = new Map();
+  aggregateMatch({ events: fixtureEvents(), lineups: fixtureLineups() }, players);
+  const striker = players.get(1);
+  assert.equal(striker.stats.goals, 1);
+  assert.equal(striker.stats.shots, 2);
+  assert.ok(Math.abs(striker.stats.xg - 0.5) < 1e-9);
+  const mid = players.get(2);
+  assert.equal(mid.stats.keyPasses, 1);
+  assert.ok(Math.abs(mid.stats.xa - 0.4) < 1e-9);
+  assert.equal(mid.stats.progressivePasses, 1);
+  assert.equal(mid.stats.progressiveCarries, 1);
+  assert.equal(positionGroup(striker), 'FW');
+  assert.equal(positionGroup(mid), 'MF');
+});
+
+test('per90 scales by minutes', () => {
+  const players = new Map();
+  aggregateMatch({ events: fixtureEvents(), lineups: fixtureLineups() }, players);
+  const r = per90(players.get(1));
+  assert.ok(Math.abs(r.goals90 - 1) < 1e-9); // 1 goal in 90 minutes
+});
+
+test('computePercentiles and similarity run on a small pool', () => {
+  const players = new Map();
+  // Three matches to pass the 180' threshold
+  for (let i = 0; i < 3; i++) aggregateMatch({ events: fixtureEvents(), lineups: fixtureLineups() }, players);
+  const pct = computePercentiles(players, { minMinutes: 180 });
+  assert.ok(pct.get(1));
+  const sims = similarPlayers(1, players, { minMinutes: 180, limit: 5 });
+  assert.equal(sims.length, 1);
+  assert.equal(sims[0].player.id, 2);
+});
+
+test('eligibility: grandparent path with claimable citizenship', () => {
+  const r = assess({
+    name: 'Test Player',
+    birth_country: 'Australia',
+    citizenships: ['Australia'],
+    grandparents_born_in: ['Malta'],
+  }, 'MLT');
+  assert.equal(r.status, 'NOW_AFTER_PAPERWORK');
+  assert.ok(r.paths.some((p) => p.type === 'grandparent'));
+  assert.equal(r.citizenship.status, 'CLAIMABLE');
+});
+
+test('eligibility: competitive caps block a switch', () => {
+  const r = assess({
+    name: 'Capped Player', birth_country: 'Italy', citizenships: ['Italy', 'San Marino'],
+    caps_for_other_nation: { competitive: true },
+  }, 'SMR');
+  assert.equal(r.status, 'INELIGIBLE');
+});
+
+test('eligibility: residency what-if path', () => {
+  const r = assess({
+    name: 'Resident Player', birth_country: 'Italy', citizenships: ['Italy'],
+    residency: { country: 'San Marino', years: 4, years_after_18: 3 },
+  }, 'SMR');
+  assert.equal(r.status, 'WHAT_IF');
+  assert.ok(r.paths.some((p) => p.type === 'residency' && p.tier === 'WHAT_IF'));
+});

--- a/openscout/web/index.html
+++ b/openscout/web/index.html
@@ -1,0 +1,184 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>OpenScout — open-data scouting</title>
+<style>
+:root { --bg:#0d1117; --card:#161b22; --line:#30363d; --fg:#e6edf3; --dim:#8b949e; --acc:#3fb950; --acc2:#58a6ff; }
+* { box-sizing: border-box; }
+body { font-family: -apple-system,'Segoe UI',Roboto,sans-serif; background:var(--bg); color:var(--fg); margin:0; }
+header { display:flex; align-items:center; gap:24px; padding:14px 24px; border-bottom:1px solid var(--line); position:sticky; top:0; background:var(--bg); z-index:5; flex-wrap:wrap; }
+header h1 { font-size:18px; margin:0; } header h1 span { color:var(--acc); }
+nav button { background:none; border:none; color:var(--dim); font-size:14px; padding:8px 12px; cursor:pointer; border-radius:6px; }
+nav button.active { color:var(--fg); background:var(--card); }
+main { max-width:1100px; margin:0 auto; padding:24px 16px; }
+.card { background:var(--card); border:1px solid var(--line); border-radius:12px; padding:20px; margin-bottom:16px; }
+table { width:100%; border-collapse:collapse; font-size:14px; }
+td,th { padding:8px 10px; border-bottom:1px solid var(--line); text-align:left; white-space:nowrap; }
+th { color:var(--dim); font-size:12px; text-transform:uppercase; cursor:pointer; }
+tr.row { cursor:pointer; } tr.row:hover { background:#1c2330; }
+input,select { background:var(--bg); color:var(--fg); border:1px solid var(--line); border-radius:8px; padding:8px 12px; font-size:14px; }
+button.primary { background:var(--acc); color:#04260f; border:none; border-radius:8px; padding:8px 16px; font-weight:700; cursor:pointer; }
+.controls { display:flex; gap:10px; flex-wrap:wrap; margin-bottom:14px; align-items:center; }
+.badge { background:var(--acc); color:#04260f; font-weight:700; border-radius:6px; padding:2px 8px; }
+.pill { background:var(--bg); border:1px solid var(--line); border-radius:99px; padding:2px 10px; font-size:12px; color:var(--dim); }
+.dim { color:var(--dim); } .small { font-size:12px; }
+.grid2 { display:grid; grid-template-columns:1fr 1fr; gap:16px; }
+@media (max-width:800px){ .grid2 { grid-template-columns:1fr; } }
+.bar { display:grid; grid-template-columns:150px 1fr 40px; gap:8px; align-items:center; margin:4px 0; font-size:13px; }
+.bar .track { background:var(--bg); border-radius:4px; height:9px; overflow:hidden; }
+.bar .fill { height:100%; border-radius:4px; }
+a { color:var(--acc2); text-decoration:none; }
+#status { font-size:13px; color:var(--dim); }
+</style>
+</head>
+<body>
+<header>
+  <h1>Open<span>Scout</span></h1>
+  <nav>
+    <button data-tab="players" class="active">Players</button>
+    <button data-tab="matches">Matches</button>
+    <button data-tab="eligibility">Eligibility</button>
+    <button data-tab="data">Data</button>
+  </nav>
+  <div id="status"></div>
+</header>
+<main>
+  <section id="tab-players">
+    <div class="controls">
+      <input id="q" placeholder="Search player or team..." style="flex:1;min-width:200px">
+      <select id="group">
+        <option value="">All positions</option>
+        <option value="GK">GK</option><option value="CB">CB</option><option value="FB">FB</option>
+        <option value="MF">MF</option><option value="AM">AM/W</option><option value="FW">FW</option>
+      </select>
+    </div>
+    <div class="card"><div id="playersTable" class="dim">Loading…</div></div>
+    <div id="playerDetail"></div>
+  </section>
+
+  <section id="tab-matches" hidden>
+    <div class="card"><div id="matchesTable" class="dim">Loading…</div></div>
+    <div id="matchDetail"></div>
+  </section>
+
+  <section id="tab-eligibility" hidden>
+    <div class="card">
+      <div class="controls">
+        <select id="fed"></select>
+        <span class="dim small">Screen the synced data pool for players whose nationality matches the federation's diaspora — candidates for an ancestry deep-dive.</span>
+      </div>
+      <div id="eligTable" class="dim">Pick a federation.</div>
+    </div>
+  </section>
+
+  <section id="tab-data" hidden>
+    <div class="card">
+      <h3 style="margin-top:0">Synced datasets</h3>
+      <div id="datasets" class="dim">Loading…</div>
+    </div>
+    <div class="card">
+      <h3 style="margin-top:0">Free competitions available (StatsBomb open data)</h3>
+      <div id="competitions" class="dim">Loading…</div>
+    </div>
+  </section>
+</main>
+<script>
+const $ = (s) => document.querySelector(s);
+const api = (p, opts) => fetch(p, opts).then((r) => r.json());
+const esc = (s) => String(s ?? '').replace(/[&<>"]/g, (c) => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const pctColor = (v) => v>=80?'#3fb950':v>=60?'#90c978':v>=40?'#d29922':v>=20?'#db6d28':'#f85149';
+
+document.querySelectorAll('nav button').forEach((b) => b.addEventListener('click', () => {
+  document.querySelectorAll('nav button').forEach((x) => x.classList.toggle('active', x === b));
+  document.querySelectorAll('main > section').forEach((s) => { s.hidden = s.id !== 'tab-' + b.dataset.tab; });
+}));
+
+// ---- Players ----
+let playersCache = [];
+async function loadPlayers() {
+  const q = $('#q').value, group = $('#group').value;
+  const params = new URLSearchParams(); if (q) params.set('q', q); if (group) params.set('group', group);
+  playersCache = await api('/api/players?' + params);
+  if (!playersCache.length) {
+    $('#playersTable').innerHTML = 'No players yet — go to the <b>Data</b> tab and sync a competition.';
+    return;
+  }
+  $('#playersTable').innerHTML = `<table><tr><th>OS</th><th>Player</th><th>Team</th><th>Pos</th><th>Min</th><th>G</th><th>A</th><th>npxG/90</th><th>xA/90</th></tr>` +
+    playersCache.map((p) => `<tr class="row" onclick="openPlayer(${p.id})">
+      <td><span class="badge">${p.rating ?? '–'}</span></td><td>${esc(p.name)}</td><td class="dim">${esc(p.team)}</td>
+      <td><span class="pill">${p.group}</span></td><td>${p.minutes}</td><td>${p.goals}</td><td>${p.assists}</td>
+      <td>${p.npxg90 ?? ''}</td><td>${p.xa90 ?? ''}</td></tr>`).join('') + '</table>';
+}
+$('#q').addEventListener('input', () => loadPlayers());
+$('#group').addEventListener('change', () => loadPlayers());
+
+window.openPlayer = async (id) => {
+  const p = await api('/api/player/' + id);
+  const bars = p.percentiles ? Object.entries(p.percentiles).sort((a,b)=>b[1]-a[1]).map(([k,v]) =>
+    `<div class="bar"><span>${k}</span><div class="track"><div class="fill" style="width:${v}%;background:${pctColor(v)}"></div></div><b>${Math.round(v)}</b></div>`).join('') : '<div class="dim">Not enough minutes for percentiles.</div>';
+  const sims = (p.similar||[]).map((s) => `<tr class="row" onclick="openPlayer(${s.id})"><td>${s.similarity}%</td><td>${esc(s.name)}</td><td class="dim">${esc(s.team)}</td><td><span class="pill">${s.group}</span></td></tr>`).join('');
+  $('#playerDetail').innerHTML = `<div class="card">
+    <h2 style="margin:0">${esc(p.name)} <span class="badge">OS ${p.rating ?? '–'}</span></h2>
+    <div class="dim" style="margin:4px 0 12px">${esc(p.team)} · ${esc(p.position)} · ${esc(p.country||'')} · ${p.minutes}' / ${p.matches} matches · ${p.goals}G ${p.assists}A
+      &nbsp; <a href="/report/player/${p.id}" target="_blank">Open full HTML report ↗</a></div>
+    <div class="grid2"><div><h4 class="dim">Percentiles vs ${p.group} group</h4>${bars}</div>
+    <div><h4 class="dim">Similar players</h4><table>${sims}</table></div></div></div>`;
+  $('#playerDetail').scrollIntoView({ behavior: 'smooth' });
+};
+
+// ---- Matches ----
+async function loadMatches() {
+  const ms = await api('/api/matches');
+  if (!ms.length) { $('#matchesTable').innerHTML = 'No matches yet — sync a competition in the <b>Data</b> tab.'; return; }
+  $('#matchesTable').innerHTML = '<table><tr><th>Date</th><th>Match</th><th>Stage</th><th>Competition</th><th></th></tr>' +
+    ms.map((m) => `<tr class="row"><td class="dim">${m.date}</td><td><b>${esc(m.home)} ${m.score} ${esc(m.away)}</b></td>
+    <td class="dim">${esc(m.stage||'')}</td><td class="dim">${esc(m.competition)} ${esc(m.season)}</td>
+    <td><a href="/report/match/${m.match_id}" target="_blank">report ↗</a></td></tr>`).join('') + '</table>';
+}
+
+// ---- Eligibility ----
+async function loadFeds() {
+  const feds = await api('/api/federations');
+  $('#fed').innerHTML = '<option value="">— federation —</option>' + feds.map((f) => `<option value="${f.code}">${f.name}</option>`).join('');
+}
+$('#fed').addEventListener('change', async () => {
+  const code = $('#fed').value; if (!code) return;
+  $('#eligTable').textContent = 'Screening…';
+  const scan = await api('/api/eligibility/' + code);
+  $('#eligTable').innerHTML = `<p class="dim small">${esc(scan.notes)}<br>Diaspora pool: ${scan.diaspora_countries.join(', ')}</p>` +
+    (scan.candidates.length ? '<table><tr><th>Player</th><th>Nationality</th><th>Team</th><th>Pos</th><th>Min</th><th>npxG+xA/90</th><th>Action</th></tr>' +
+    scan.candidates.slice(0,100).map((c) => `<tr class="row" onclick="openPlayerFromElig(${c.id})"><td>${esc(c.name)}</td><td>${esc(c.nationality)}</td><td class="dim">${esc(c.team)}</td>
+    <td><span class="pill">${c.position}</span></td><td>${c.minutes}</td><td>${c.npxgPlusXa90}</td><td class="small dim">ancestry deep-dive</td></tr>`).join('') + '</table>'
+    : '<div class="dim">No diaspora-nationality players in the synced pool. Sync more competitions.</div>');
+});
+window.openPlayerFromElig = (id) => { document.querySelector('[data-tab=players]').click(); openPlayer(id); };
+
+// ---- Data ----
+async function loadData() {
+  const ds = await api('/api/datasets');
+  $('#datasets').innerHTML = ds.length
+    ? '<table><tr><th>Competition</th><th>Matches</th><th>Players</th><th>Synced</th></tr>' +
+      ds.map((d) => `<tr><td>${esc(d.competition)} ${esc(d.season)}</td><td>${d.matches}</td><td>${d.players}</td><td class="dim">${d.synced_at.slice(0,10)}</td></tr>`).join('') + '</table>'
+    : 'Nothing synced yet.';
+  const comps = await api('/api/competitions');
+  $('#competitions').innerHTML = '<table><tr><th>Competition</th><th>Season</th><th>Country</th><th></th></tr>' +
+    comps.map((c) => `<tr><td>${esc(c.name)} <span class="pill">${c.gender}</span></td><td>${esc(c.season)}</td><td class="dim">${esc(c.country)}</td>
+    <td><button class="primary" onclick="sync(${c.competition_id},${c.season_id},this)">Sync</button></td></tr>`).join('') + '</table>';
+}
+window.sync = async (comp, season, btn) => {
+  btn.disabled = true; btn.textContent = 'Syncing…';
+  $('#status').textContent = 'Downloading event data (first sync of a big league can take a few minutes)…';
+  try {
+    const r = await api(`/api/sync?competition_id=${comp}&season_id=${season}`, { method: 'POST' });
+    $('#status').textContent = `Synced: ${r.matches} matches, ${r.players} players.`;
+    await Promise.all([loadPlayers(), loadMatches(), loadData()]);
+  } catch (e) { $('#status').textContent = 'Sync failed: ' + e.message; }
+  btn.disabled = false; btn.textContent = 'Sync';
+};
+
+loadPlayers(); loadMatches(); loadFeds(); loadData();
+</script>
+</body>
+</html>

--- a/scoutpad/README.md
+++ b/scoutpad/README.md
@@ -1,0 +1,102 @@
+# ScoutPad — il taccuino digitale dello scout
+
+**PWA mobile, offline-first, zero backend.** Tagging live a bordo campo,
+scheda di valutazione, report HTML professionale condivisibile su WhatsApp.
+Distribuibile **oggi**: è un sito statico, niente app store, niente server.
+
+## Il bisogno non soddisfatto
+
+Nei dilettanti, nelle giovanili e nelle leghe minori **le partite non hanno né
+video né dati**: Wyscout e InStat lì semplicemente non esistono. Lo scout in
+tribuna è l'unico sensore — e oggi lavora con taccuino di carta, memoria e
+WhatsApp. Procuratori, osservatori, DS di Serie C/D e settori giovanili:
+migliaia di professionisti senza strumenti, che devono comunque produrre
+relazioni credibili per club e agenzie.
+
+ScoutPad trasforma il telefono che hanno già in tasca nello strumento di
+lavoro: si installa dalla home screen, funziona senza rete (campi di periferia
+inclusi), e il report che esce sembra fatto da un'area scouting professionale.
+
+## Cosa fa
+
+- **Setup partita in 30 secondi**: squadre, competizione, giocatori da osservare.
+- **Tagging live a un tocco**: 16 eventi (gol, tiri, dribbling, duelli, recuperi,
+  palle perse, falli, parate, errori...) col cronometro della partita; undo,
+  note rapide, vibrazione di conferma.
+- **Scheda di valutazione**: 6 categorie (tecnica, tattica, fisico, velocità,
+  mentalità, personalità) su scala 1–10, verdetto FIRMARE / MONITORARE /
+  SCARTARE, note libere.
+- **Report HTML autosufficiente** con radar SVG, statistiche evento, timeline e
+  note — condiviso direttamente su WhatsApp/Telegram via share nativo, o
+  stampabile in PDF dal browser.
+- **Dati solo sul telefono** (localStorage) + backup/ripristino JSON. Niente
+  account, niente GDPR-grattacapi, costo server: zero.
+
+## Distribuirlo adesso (10 minuti)
+
+1. Merge su `main`: il workflow `.github/workflows/deploy-scoutpad.yml`
+   pubblica l'app su GitHub Pages (attiva una volta sola
+   *Settings → Pages → Source: GitHub Actions*).
+2. L'app è live su `https://<utente>.github.io/<repo>/` — manda il link:
+   chi lo apre dal telefono può fare "Aggiungi a schermata Home" e ha l'app.
+3. (Dopo) dominio proprio: `scoutpad.app` o simile puntato a Pages, €10/anno.
+   Costo totale di esercizio: €10/anno.
+
+Test locale: `node serve.js` → http://localhost:8080 (oppure da telefono sulla
+stessa rete).
+
+## Monetizzare adesso
+
+Modello: **freemium con licenza a vita**. 3 report gratuiti, poi sblocco PRO.
+
+1. Crea il prodotto su Gumroad (o Stripe Payment Link): *"ScoutPad PRO —
+   licenza a vita"*, prezzo lancio **€49** (ancoraggio: Wyscout parte da
+   ~€5.000/anno).
+2. Cambia `LICENSE_SECRET` in `app.js` e metti l'URL del prodotto in `BUY_URL`.
+3. A ogni vendita Gumroad ti notifica l'email dell'acquirente: generi la chiave
+   con `SCOUTPAD_SECRET=tuo-secret node tools/genkey.js email@cliente.it` e
+   gliela mandi (2 minuti; automatizzabile poi con un webhook).
+
+> La validazione licenza è volutamente "soft" (HMAC client-side): tiene onesti
+> gli onesti. A questo prezzo e per questo pubblico è il trade-off giusto —
+> zero infrastruttura.
+
+### Go-to-market della prima settimana
+
+- **Canale diretto**: gruppi WhatsApp/Facebook di procuratori e osservatori
+  (es. "osservatori calcio", AIPES, corsi da osservatore), DS di Eccellenza/
+  Promozione/Serie D. Pitch: *"il report che mandi al club, fatto dal telefono
+  mentre guardi la partita — gratis per 3 partite"*.
+- **Effetto virale incorporato**: ogni report condiviso porta il footer
+  ScoutPad davanti a DS e procuratori — il destinatario del report È il
+  prossimo cliente.
+- **Corsi per osservatori**: licenze in blocco scontate come materiale
+  didattico.
+
+## Sinergia con OpenScout
+
+ScoutPad genera dati proprietari su partite che nessun data provider copre.
+È il punto d'ingresso del funnel: i dati taggati alimenteranno le metriche di
+[OpenScout](../openscout/README.md) (import previsto in roadmap) e le shortlist
+di Eligibility Intelligence — la strategia completa è in
+[openscout/STRATEGY.md](../openscout/STRATEGY.md).
+
+## Sviluppo
+
+```bash
+node serve.js          # server locale su :8080
+npm install && npm test   # smoke test del flusso completo (jsdom, solo dev)
+node tools/genkey.js email@cliente.it   # genera chiave licenza
+```
+
+File: `index.html` (shell+stili) · `app.js` (tutta la logica) · `sw.js`
+(offline) · `manifest.webmanifest` + `icon.svg` (installabilità PWA).
+Zero dipendenze a runtime.
+
+## Roadmap
+
+- [ ] Webhook Gumroad → consegna automatica della chiave
+- [ ] Note vocali (Web Speech API) durante il live
+- [ ] Export CSV eventi → import in OpenScout
+- [ ] Shortlist multi-partita per giocatore (storico osservazioni)
+- [ ] Modalità squadra: due scout, stessa partita, report unificato

--- a/scoutpad/README.md
+++ b/scoutpad/README.md
@@ -32,15 +32,21 @@ inclusi), e il report che esce sembra fatto da un'area scouting professionale.
 - **Dati solo sul telefono** (localStorage) + backup/ripristino JSON. Niente
   account, niente GDPR-grattacapi, costo server: zero.
 
-## Distribuirlo adesso (10 minuti)
+## Distribuirlo adesso
 
-1. Merge su `main`: il workflow `.github/workflows/deploy-scoutpad.yml`
-   pubblica l'app su GitHub Pages (attiva una volta sola
-   *Settings → Pages → Source: GitHub Actions*).
-2. L'app è live su `https://<utente>.github.io/<repo>/` — manda il link:
-   chi lo apre dal telefono può fare "Aggiungi a schermata Home" e ha l'app.
-3. (Dopo) dominio proprio: `scoutpad.app` o simile puntato a Pages, €10/anno.
-   Costo totale di esercizio: €10/anno.
+Il repo ha già GitHub Pages attivo in modalità "deploy from branch" su `main`:
+**basta il merge su main** e l'app è online su
+
+> **https://mtornani.github.io/App1/scoutpad/**
+
+senza toccare alcuna impostazione (Pages copia i file statici così come sono).
+Chi apre il link dal telefono fa "Aggiungi a schermata Home" e ha l'app.
+
+Opzionale, per avere ScoutPad alla radice dell'URL (`/App1/`): imposta
+*Settings → Pages → Source: GitHub Actions* e lancia manualmente il workflow
+`.github/workflows/deploy-scoutpad.yml` (sostituisce il sito attuale del
+README). Dominio proprio (es. `scoutpad.app`): €10/anno, costo totale di
+esercizio.
 
 Test locale: `node serve.js` → http://localhost:8080 (oppure da telefono sulla
 stessa rete).

--- a/scoutpad/app.js
+++ b/scoutpad/app.js
@@ -1,0 +1,501 @@
+/* ScoutPad — taccuino digitale per scout: tagging live, valutazioni, report.
+   Offline-first: tutti i dati vivono in localStorage sul telefono dello scout. */
+'use strict';
+
+// ---------- Config ----------
+const BUY_URL = 'https://gumroad.com/l/scoutpad-pro'; // sostituisci col tuo prodotto Gumroad/Stripe
+const FREE_REPORTS = 3;
+// Cambia questo secret PRIMA di vendere licenze e rigenera le chiavi con tools/genkey.js.
+// Protezione "soft": tiene onesti gli onesti, non ferma un developer determinato.
+const LICENSE_SECRET = 'scoutpad-change-me';
+
+const EVENT_TYPES = [
+  { code: 'goal', label: 'Gol', icon: '⚽', sign: 'pos' },
+  { code: 'shot_on', label: 'Tiro in porta', icon: '🎯', sign: 'pos' },
+  { code: 'shot_off', label: 'Tiro fuori', icon: '💨', sign: 'neg' },
+  { code: 'assist', label: 'Assist', icon: '🅰️', sign: 'pos' },
+  { code: 'key_pass', label: 'Pass. chiave', icon: '🔑', sign: 'pos' },
+  { code: 'dribble_won', label: 'Dribbling ✓', icon: '🪄', sign: 'pos' },
+  { code: 'dribble_lost', label: 'Dribbling ✗', icon: '🚧', sign: 'neg' },
+  { code: 'duel_won', label: 'Duello vinto', icon: '💪', sign: 'pos' },
+  { code: 'duel_lost', label: 'Duello perso', icon: '🥀', sign: 'neg' },
+  { code: 'recovery', label: 'Recupero', icon: '🧲', sign: 'pos' },
+  { code: 'loss', label: 'Palla persa', icon: '🕳️', sign: 'neg' },
+  { code: 'cross', label: 'Cross', icon: '🌙', sign: 'pos' },
+  { code: 'foul_won', label: 'Fallo subito', icon: '🩹', sign: 'pos' },
+  { code: 'foul', label: 'Fallo fatto', icon: '🟨', sign: 'neg' },
+  { code: 'save', label: 'Parata', icon: '🧤', sign: 'pos' },
+  { code: 'error', label: 'Errore grave', icon: '❌', sign: 'neg' },
+];
+const EV = Object.fromEntries(EVENT_TYPES.map((e) => [e.code, e]));
+
+const CATEGORIES = [
+  ['tecnica', 'Tecnica'], ['tattica', 'Tattica'], ['fisico', 'Fisico'],
+  ['velocita', 'Velocità'], ['mentalita', 'Mentalità'], ['personalita', 'Personalità'],
+];
+const VERDICTS = { sign: 'FIRMARE', watch: 'MONITORARE', pass: 'SCARTARE' };
+
+// ---------- State ----------
+const STORE_KEY = 'scoutpad-v1';
+let state = load();
+let view = { name: 'home', sessionId: null, playerId: null };
+let clockTimer = null;
+
+function load() {
+  try {
+    const raw = localStorage.getItem(STORE_KEY);
+    if (raw) return JSON.parse(raw);
+  } catch (e) { /* corrotto: riparti pulito */ }
+  return { sessions: [], reports: 0, license: null };
+}
+function save() { localStorage.setItem(STORE_KEY, JSON.stringify(state)); }
+const uid = () => Math.random().toString(36).slice(2, 10);
+const $ = (s) => document.querySelector(s);
+const esc = (s) => String(s ?? '').replace(/[&<>"]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]));
+const session = () => state.sessions.find((s) => s.id === view.sessionId);
+
+function toast(msg) {
+  const t = $('#toast');
+  t.textContent = msg;
+  t.classList.add('show');
+  clearTimeout(t._h);
+  t._h = setTimeout(() => t.classList.remove('show'), 2200);
+}
+
+// ---------- Clock ----------
+function clockSeconds(s) {
+  const c = s.clock;
+  return c.base + (c.startedAt ? (Date.now() - c.startedAt) / 1000 : 0);
+}
+function currentMinute(s) {
+  return s.clock.halfStartMin + Math.floor(clockSeconds(s) / 60);
+}
+function clockLabel(s) {
+  const sec = Math.floor(clockSeconds(s));
+  const m = String(s.clock.halfStartMin + Math.floor(sec / 60)).padStart(2, '0');
+  return `${m}:${String(sec % 60).padStart(2, '0')}`;
+}
+
+// ---------- Licensing ----------
+async function keyForEmail(email) {
+  const enc = new TextEncoder();
+  const k = await crypto.subtle.importKey('raw', enc.encode(LICENSE_SECRET), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+  const sig = await crypto.subtle.sign('HMAC', k, enc.encode(email.trim().toLowerCase()));
+  const hex = [...new Uint8Array(sig)].map((b) => b.toString(16).padStart(2, '0')).join('').slice(0, 16).toUpperCase();
+  return hex.match(/.{4}/g).join('-');
+}
+async function activateLicense(email, key) {
+  if (!crypto.subtle) { toast('Serve HTTPS per attivare la licenza'); return false; }
+  const expected = await keyForEmail(email);
+  if (expected === key.trim().toUpperCase()) {
+    state.license = { email: email.trim().toLowerCase(), key: expected };
+    save();
+    return true;
+  }
+  return false;
+}
+const isPro = () => !!state.license;
+const reportsLeft = () => Math.max(0, FREE_REPORTS - state.reports);
+
+// ---------- Render ----------
+function render() {
+  clearInterval(clockTimer);
+  $('#hdrRight').innerHTML = isPro()
+    ? '<span class="badge">PRO</span>'
+    : `${reportsLeft()}/${FREE_REPORTS} report gratis`;
+  const r = { home: renderHome, setup: renderSetup, live: renderLive, eval: renderEval, paywall: renderPaywall }[view.name];
+  $('#app').innerHTML = r();
+  bind();
+  if (view.name === 'live') {
+    clockTimer = setInterval(() => {
+      const s = session();
+      const el = $('#clockTime');
+      if (s && el) el.textContent = clockLabel(s);
+    }, 1000);
+  }
+}
+
+function renderHome() {
+  const items = state.sessions.slice().reverse().map((s) => `
+    <div class="card session-item">
+      <div style="min-width:0">
+        <h3>${esc(s.home)} – ${esc(s.away)}</h3>
+        <div class="dim small">${esc(s.date)} · ${esc(s.competition || '')} · ${s.players.length} osservati · ${s.events.length} eventi</div>
+      </div>
+      <div style="flex:0 0 auto">
+        <button class="btn-ghost" data-open="${s.id}">Apri</button>
+        <button class="btn-danger" data-del="${s.id}">✕</button>
+      </div>
+    </div>`).join('');
+  return `
+    <button class="btn-primary" id="newMatch">+ Nuova partita</button>
+    <div style="height:14px"></div>
+    ${items || '<div class="card dim">Nessuna partita. Creane una e inizia a taggare dal vivo: funziona anche senza rete, a bordo campo.</div>'}
+    <div class="card">
+      <h2>Backup</h2>
+      <div class="row">
+        <button class="btn" id="exportData" style="text-align:center">Esporta dati</button>
+        <button class="btn" id="importData" style="text-align:center">Importa</button>
+      </div>
+      ${isPro() ? `<div class="small dim">Licenza PRO attiva: ${esc(state.license.email)}</div>`
+        : `<button class="btn-ghost" id="goPro">Hai una licenza? Attiva ScoutPad PRO →</button>`}
+    </div>
+    <div class="muted-link">ScoutPad · i dati restano sul tuo telefono · parte di OpenScout</div>
+    <input type="file" id="importFile" accept="application/json" hidden>`;
+}
+
+function renderSetup() {
+  return `
+    <div class="card">
+      <h2>Nuova partita</h2>
+      <div class="row">
+        <div><label>Casa</label><input id="fHome" placeholder="Es. Cesena U19"></div>
+        <div><label>Ospite</label><input id="fAway" placeholder="Es. Rimini U19"></div>
+      </div>
+      <div class="row">
+        <div><label>Data</label><input id="fDate" type="date" value="${new Date().toISOString().slice(0, 10)}"></div>
+        <div><label>Competizione</label><input id="fComp" placeholder="Es. Primavera 2"></div>
+      </div>
+    </div>
+    <div class="card">
+      <h2>Giocatori da osservare</h2>
+      <div id="playerRows"></div>
+      <button class="btn" id="addPlayer" style="text-align:center">+ Aggiungi giocatore</button>
+      <div class="small dim">Numero di maglia, nome, squadra e ruolo. Puoi osservarne più d'uno nella stessa partita.</div>
+    </div>
+    <button class="btn-primary" id="startMatch">Inizia osservazione</button>
+    <button class="btn-ghost" id="backHome">← Annulla</button>`;
+}
+
+function playerRowHTML() {
+  return `
+    <div class="row player-row" style="margin-bottom:8px">
+      <input class="pNum" placeholder="N°" inputmode="numeric" style="flex:0 0 64px">
+      <input class="pName" placeholder="Nome" style="flex:2">
+      <select class="pTeam" style="flex:1"><option>Casa</option><option>Ospite</option></select>
+      <input class="pPos" placeholder="Ruolo" style="flex:1">
+    </div>`;
+}
+
+function renderLive() {
+  const s = session();
+  const sel = s.players.find((p) => p.id === view.playerId) || s.players[0];
+  if (sel) view.playerId = sel.id;
+  const chips = s.players.map((p) =>
+    `<button class="chip ${p.id === view.playerId ? 'active' : ''}" data-player="${p.id}">${p.number ? '#' + esc(p.number) + ' ' : ''}${esc(p.name)}</button>`).join('');
+  const grid = EVENT_TYPES.map((e) =>
+    `<button class="evbtn ${e.sign}" data-ev="${e.code}"><b>${e.icon}</b>${e.label}</button>`).join('');
+  const feed = s.events.slice(-30).reverse().map((e) => {
+    const p = s.players.find((x) => x.id === e.playerId);
+    return `<div><span>${e.min}' ${EV[e.type].icon} ${EV[e.type].label} — <b>${esc(p ? p.name : '?')}</b></span></div>`;
+  }).join('');
+  const c = s.clock;
+  return `
+    <div class="card clock">
+      <div class="time" id="clockTime">${clockLabel(s)}</div>
+      <div style="display:flex;gap:8px">
+        <button class="btn" id="clockToggle" style="width:auto;margin:0">${c.startedAt ? '⏸ Pausa' : '▶ Avvia'}</button>
+        <button class="btn" id="clockHalf" style="width:auto;margin:0">${c.halfStartMin === 0 ? '2° T' : '⏹'}</button>
+      </div>
+    </div>
+    <div class="chips">${chips || '<span class="dim">Nessun giocatore osservato</span>'}</div>
+    <div class="evgrid">${grid}</div>
+    <div style="height:10px"></div>
+    <div class="row">
+      <input id="quickNote" placeholder="Nota rapida (es. 'gran movimento senza palla')">
+      <button class="btn" id="addNote" style="flex:0 0 64px;text-align:center;margin:0">＋</button>
+    </div>
+    <div class="card">
+      <div class="topbar"><h2 style="margin:0">Eventi (${s.events.length})</h2>
+        <button class="btn-ghost" id="undo">↩ Annulla ultimo</button></div>
+      <div class="feed">${feed || '<span class="dim small">Tocca un giocatore e poi un evento.</span>'}</div>
+    </div>
+    <button class="btn-primary" id="goEval">Valutazioni e report →</button>
+    <button class="btn-ghost" id="backHome">← Partite</button>`;
+}
+
+function renderEval() {
+  const s = session();
+  const p = s.players.find((x) => x.id === view.playerId) || s.players[0];
+  if (!p) return '<div class="card dim">Nessun giocatore osservato in questa partita.</div><button class="btn-ghost" id="backLive">← Indietro</button>';
+  view.playerId = p.id;
+  const ev = (s.evals[p.id] = s.evals[p.id] || { scores: {}, verdict: null, notes: '' });
+  const chips = s.players.map((x) =>
+    `<button class="chip ${x.id === p.id ? 'active' : ''}" data-player="${x.id}">${esc(x.name)}</button>`).join('');
+  const counts = countEvents(s, p.id);
+  const summary = EVENT_TYPES.filter((e) => counts[e.code])
+    .map((e) => `<span class="pill">${e.icon} ${e.label}: <b>${counts[e.code]}</b></span>`).join(' ') || '<span class="dim small">Nessun evento taggato.</span>';
+  const sliders = CATEGORIES.map(([k, label]) => `
+    <div class="slider-row"><span>${label}</span>
+      <input type="range" min="1" max="10" step="1" value="${ev.scores[k] || 6}" data-score="${k}">
+      <b id="sv-${k}">${ev.scores[k] || 6}</b></div>`).join('');
+  return `
+    <div class="chips">${chips}</div>
+    <div class="card">
+      <h3>${p.number ? '#' + esc(p.number) + ' ' : ''}${esc(p.name)} <span class="pill">${esc(p.pos || '')}</span></h3>
+      <div style="margin:8px 0 14px">${summary}</div>
+      ${sliders}
+      <label style="margin-top:10px">Verdetto</label>
+      <div class="verdict">
+        <button class="v-sign ${ev.verdict === 'sign' ? 'on' : ''}" data-verdict="sign">FIRMARE</button>
+        <button class="v-watch ${ev.verdict === 'watch' ? 'on' : ''}" data-verdict="watch">MONITORARE</button>
+        <button class="v-pass ${ev.verdict === 'pass' ? 'on' : ''}" data-verdict="pass">SCARTARE</button>
+      </div>
+      <label style="margin-top:12px">Note dello scout</label>
+      <textarea id="evalNotes" placeholder="Punti di forza, debolezze, contesto, proiezione...">${esc(ev.notes)}</textarea>
+    </div>
+    <button class="btn-primary" id="makeReport">📄 Genera report partita</button>
+    <button class="btn-ghost" id="backLive">← Torna al live</button>`;
+}
+
+function renderPaywall() {
+  return `
+    <div class="card lock">
+      <div class="big">🔓</div>
+      <h3>Hai usato i ${FREE_REPORTS} report gratuiti</h3>
+      <p class="dim">ScoutPad PRO sblocca report illimitati per sempre. Una licenza, tutti i tuoi dispositivi.</p>
+      <button class="btn-primary" id="buy">Acquista ScoutPad PRO</button>
+    </div>
+    <div class="card">
+      <h2>Ho già una licenza</h2>
+      <label>Email d'acquisto</label><input id="licEmail" type="email" placeholder="email@esempio.it">
+      <label>Chiave licenza</label><input id="licKey" placeholder="XXXX-XXXX-XXXX-XXXX" autocapitalize="characters">
+      <button class="btn-primary" id="activate">Attiva</button>
+    </div>
+    <button class="btn-ghost" id="backHome">← Indietro</button>`;
+}
+
+// ---------- Events / actions ----------
+function countEvents(s, playerId) {
+  const out = {};
+  for (const e of s.events) if (e.playerId === playerId) out[e.type] = (out[e.type] || 0) + 1;
+  return out;
+}
+
+function bind() {
+  const on = (sel, fn) => { const el = $(sel); if (el) el.addEventListener('click', fn); };
+
+  on('#newMatch', () => { view = { name: 'setup' }; render(); setupAddRow(); });
+  on('#backHome', () => { view = { name: 'home' }; render(); });
+  on('#goPro', () => { view = { name: 'paywall' }; render(); });
+  on('#buy', () => window.open(BUY_URL, '_blank'));
+
+  document.querySelectorAll('[data-open]').forEach((b) => b.addEventListener('click', () => {
+    view = { name: 'live', sessionId: b.dataset.open };
+    render();
+  }));
+  document.querySelectorAll('[data-del]').forEach((b) => b.addEventListener('click', () => {
+    if (!confirm('Eliminare questa partita e tutti i suoi dati?')) return;
+    state.sessions = state.sessions.filter((s) => s.id !== b.dataset.del);
+    save(); render();
+  }));
+
+  on('#exportData', () => {
+    downloadFile(`scoutpad-backup-${Date.now()}.json`, JSON.stringify(state), 'application/json');
+  });
+  on('#importData', () => $('#importFile').click());
+  const imp = $('#importFile');
+  if (imp) imp.addEventListener('change', async () => {
+    try {
+      const incoming = JSON.parse(await imp.files[0].text());
+      if (!Array.isArray(incoming.sessions)) throw new Error('formato non valido');
+      state = incoming; save(); render(); toast('Backup importato');
+    } catch (e) { toast('File non valido'); }
+  });
+
+  // Setup
+  on('#addPlayer', setupAddRow);
+  on('#startMatch', () => {
+    const players = [...document.querySelectorAll('.player-row')].map((r) => ({
+      id: uid(),
+      number: r.querySelector('.pNum').value.trim(),
+      name: r.querySelector('.pName').value.trim(),
+      team: r.querySelector('.pTeam').value,
+      pos: r.querySelector('.pPos').value.trim(),
+    })).filter((p) => p.name);
+    const s = {
+      id: uid(),
+      home: $('#fHome').value.trim() || 'Casa',
+      away: $('#fAway').value.trim() || 'Ospite',
+      date: $('#fDate').value,
+      competition: $('#fComp').value.trim(),
+      players,
+      events: [],
+      notes: [],
+      evals: {},
+      clock: { base: 0, startedAt: null, halfStartMin: 0 },
+    };
+    state.sessions.push(s); save();
+    view = { name: 'live', sessionId: s.id, playerId: players[0]?.id };
+    render();
+  });
+
+  // Live
+  document.querySelectorAll('[data-player]').forEach((b) => b.addEventListener('click', () => {
+    view.playerId = b.dataset.player; render();
+  }));
+  document.querySelectorAll('[data-ev]').forEach((b) => b.addEventListener('click', () => {
+    const s = session();
+    if (!view.playerId) { toast('Seleziona prima un giocatore'); return; }
+    s.events.push({ t: Date.now(), min: currentMinute(s), playerId: view.playerId, type: b.dataset.ev });
+    save();
+    const p = s.players.find((x) => x.id === view.playerId);
+    toast(`${EV[b.dataset.ev].icon} ${EV[b.dataset.ev].label} — ${p.name}`);
+    if (navigator.vibrate) navigator.vibrate(15);
+    render();
+  }));
+  on('#undo', () => { const s = session(); s.events.pop(); save(); render(); });
+  on('#clockToggle', () => {
+    const s = session(); const c = s.clock;
+    if (c.startedAt) { c.base += (Date.now() - c.startedAt) / 1000; c.startedAt = null; }
+    else c.startedAt = Date.now();
+    save(); render();
+  });
+  on('#clockHalf', () => {
+    const s = session(); const c = s.clock;
+    if (c.halfStartMin === 0) { c.halfStartMin = 45; c.base = 0; c.startedAt = null; toast('Secondo tempo'); }
+    else { if (c.startedAt) { c.base += (Date.now() - c.startedAt) / 1000; c.startedAt = null; } toast('Partita conclusa'); }
+    save(); render();
+  });
+  on('#addNote', () => {
+    const s = session(); const txt = $('#quickNote').value.trim();
+    if (!txt) return;
+    s.notes.push({ min: currentMinute(s), playerId: view.playerId, text: txt });
+    save(); $('#quickNote').value = ''; toast('Nota salvata');
+  });
+  on('#goEval', () => { view.name = 'eval'; render(); });
+  on('#backLive', () => { view.name = 'live'; render(); });
+
+  // Eval
+  document.querySelectorAll('[data-score]').forEach((r) => r.addEventListener('input', () => {
+    const s = session();
+    s.evals[view.playerId].scores[r.dataset.score] = Number(r.value);
+    $('#sv-' + r.dataset.score).textContent = r.value;
+    save();
+  }));
+  document.querySelectorAll('[data-verdict]').forEach((b) => b.addEventListener('click', () => {
+    const s = session();
+    s.evals[view.playerId].verdict = b.dataset.verdict;
+    save(); render();
+  }));
+  const notes = $('#evalNotes');
+  if (notes) notes.addEventListener('input', () => {
+    session().evals[view.playerId].notes = notes.value; save();
+  });
+  on('#makeReport', generateReport);
+
+  // Paywall
+  on('#activate', async () => {
+    const ok = await activateLicense($('#licEmail').value, $('#licKey').value);
+    if (ok) { toast('ScoutPad PRO attivato 🎉'); view = { name: 'home' }; render(); }
+    else toast('Chiave non valida per questa email');
+  });
+}
+
+function setupAddRow() {
+  const div = document.createElement('div');
+  div.innerHTML = playerRowHTML();
+  $('#playerRows').appendChild(div.firstElementChild);
+}
+
+// ---------- Report ----------
+function radarSVG(labels, values, size = 320) {
+  const cx = size / 2, cy = size / 2, R = size / 2 - 52, n = labels.length;
+  const pt = (i, r) => {
+    const a = (Math.PI * 2 * i) / n - Math.PI / 2;
+    return [cx + r * Math.cos(a), cy + r * Math.sin(a)];
+  };
+  let out = '';
+  for (const f of [0.25, 0.5, 0.75, 1]) {
+    out += `<polygon points="${labels.map((_, i) => pt(i, R * f).join(',')).join(' ')}" fill="none" stroke="#30363d"/>`;
+  }
+  out += labels.map((_, i) => { const [x, y] = pt(i, R); return `<line x1="${cx}" y1="${cy}" x2="${x}" y2="${y}" stroke="#30363d"/>`; }).join('');
+  out += `<polygon points="${labels.map((_, i) => pt(i, (R * values[i]) / 10).join(',')).join(' ')}" fill="rgba(63,185,80,.3)" stroke="#3fb950" stroke-width="2"/>`;
+  out += labels.map((l, i) => {
+    const [x, y] = pt(i, R + 26);
+    return `<text x="${x}" y="${y}" fill="#8b949e" font-size="12" text-anchor="middle">${l} <tspan fill="#e6edf3" font-weight="bold">${values[i]}</tspan></text>`;
+  }).join('');
+  return `<svg viewBox="0 0 ${size} ${size}" width="100%" style="max-width:${size}px;display:block;margin:0 auto" xmlns="http://www.w3.org/2000/svg">${out}</svg>`;
+}
+
+function reportHTML(s) {
+  const vColor = { sign: '#3fb950', watch: '#d29922', pass: '#f85149' };
+  const playerBlocks = s.players.map((p) => {
+    const ev = s.evals[p.id] || { scores: {}, verdict: null, notes: '' };
+    const counts = countEvents(s, p.id);
+    const stats = EVENT_TYPES.filter((e) => counts[e.code])
+      .map((e) => `<div class="stat"><b>${counts[e.code]}</b><span>${e.icon} ${e.label}</span></div>`).join('');
+    const radar = radarSVG(CATEGORIES.map(([, l]) => l), CATEGORIES.map(([k]) => ev.scores[k] || 6));
+    const avg = (CATEGORIES.reduce((a, [k]) => a + (ev.scores[k] || 6), 0) / CATEGORIES.length).toFixed(1);
+    const timeline = s.events.filter((e) => e.playerId === p.id)
+      .map((e) => `<tr><td>${e.min}'</td><td>${EV[e.type].icon} ${EV[e.type].label}</td></tr>`).join('');
+    const pNotes = s.notes.filter((n) => n.playerId === p.id)
+      .map((n) => `<li><b>${n.min}'</b> ${esc(n.text)}</li>`).join('');
+    return `
+    <div class="card">
+      <h2 style="font-size:20px;color:#e6edf3;text-transform:none;letter-spacing:0">
+        ${p.number ? '#' + esc(p.number) + ' ' : ''}${esc(p.name)}
+        ${ev.verdict ? `<span class="verdict" style="background:${vColor[ev.verdict]}">${VERDICTS[ev.verdict]}</span>` : ''}
+      </h2>
+      <div class="dim">${esc(p.pos || '')} · ${p.team === 'Casa' ? esc(s.home) : esc(s.away)} · media valutazione <b style="color:#e6edf3">${avg}/10</b></div>
+      <div style="margin:16px 0">${radar}</div>
+      ${stats ? `<div class="grid">${stats}</div>` : ''}
+      ${ev.notes ? `<h3>Note dello scout</h3><p>${esc(ev.notes).replace(/\n/g, '<br>')}</p>` : ''}
+      ${pNotes ? `<h3>Appunti live</h3><ul>${pNotes}</ul>` : ''}
+      ${timeline ? `<h3>Timeline eventi</h3><table>${timeline}</table>` : ''}
+    </div>`;
+  }).join('');
+
+  return `<!doctype html><html lang="it"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Report scouting — ${esc(s.home)} vs ${esc(s.away)}</title><style>
+body{font-family:-apple-system,'Segoe UI',Roboto,sans-serif;background:#0d1117;color:#e6edf3;margin:0;padding:28px 14px}
+.wrap{max-width:760px;margin:0 auto}
+.card{background:#161b22;border:1px solid #30363d;border-radius:14px;padding:22px;margin-bottom:14px}
+h1{margin:0 0 4px;font-size:24px} h2{font-size:14px;color:#8b949e;text-transform:uppercase;letter-spacing:.06em;margin:0 0 10px}
+h3{font-size:13px;color:#8b949e;text-transform:uppercase;margin:18px 0 6px}
+.dim{color:#8b949e;font-size:14px}
+.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(110px,1fr));gap:10px;margin-top:14px}
+.stat{background:#0d1117;border:1px solid #30363d;border-radius:10px;padding:8px 10px}
+.stat b{display:block;font-size:18px}.stat span{color:#8b949e;font-size:11px}
+.verdict{color:#04260f;font-weight:800;border-radius:8px;padding:3px 12px;font-size:13px;vertical-align:middle}
+table{border-collapse:collapse;width:100%;font-size:14px} td{padding:5px 8px;border-bottom:1px solid #30363d}
+ul{padding-left:18px;font-size:14px} p{font-size:14px;line-height:1.5}
+.footer{color:#8b949e;font-size:12px;text-align:center;margin-top:22px}
+@media print{body{background:#fff;color:#111}.card{border-color:#ddd;background:#fff}}
+</style></head><body><div class="wrap">
+<div class="card"><h1>${esc(s.home)} – ${esc(s.away)}</h1>
+<div class="dim">${esc(s.date)}${s.competition ? ' · ' + esc(s.competition) : ''} · ${s.events.length} eventi taggati dal vivo</div></div>
+${playerBlocks}
+<div class="footer">Report generato con ScoutPad · scoutpad.app</div>
+</div></body></html>`;
+}
+
+function downloadFile(name, content, type) {
+  const blob = new Blob([content], { type });
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(blob);
+  a.download = name;
+  a.click();
+  setTimeout(() => URL.revokeObjectURL(a.href), 5000);
+}
+
+async function generateReport() {
+  if (!isPro() && state.reports >= FREE_REPORTS) { view.name = 'paywall'; render(); return; }
+  const s = session();
+  const html = reportHTML(s);
+  const name = `report-${s.home}-${s.away}-${s.date}.html`.replace(/\s+/g, '-').toLowerCase();
+  const file = new File([html], name, { type: 'text/html' });
+  state.reports += 1; save();
+  if (navigator.canShare && navigator.canShare({ files: [file] })) {
+    try {
+      await navigator.share({ files: [file], title: 'Report scouting' });
+      toast('Report condiviso'); render();
+      return;
+    } catch (e) { /* annullato: fallback al download */ }
+  }
+  downloadFile(name, html, 'text/html');
+  toast('Report scaricato');
+  render();
+}
+
+render();

--- a/scoutpad/icon.svg
+++ b/scoutpad/icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="112" fill="#0d1117"/>
+  <circle cx="256" cy="232" r="118" fill="none" stroke="#3fb950" stroke-width="26"/>
+  <path d="M256 168l60 44-23 70h-74l-23-70z" fill="#3fb950"/>
+  <rect x="148" y="388" width="216" height="34" rx="17" fill="#58a6ff"/>
+</svg>

--- a/scoutpad/index.html
+++ b/scoutpad/index.html
@@ -1,0 +1,87 @@
+<!doctype html>
+<html lang="it">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover,user-scalable=no">
+<meta name="theme-color" content="#0d1117">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+<link rel="manifest" href="manifest.webmanifest">
+<link rel="icon" href="icon.svg">
+<link rel="apple-touch-icon" href="icon.svg">
+<title>ScoutPad — il taccuino digitale dello scout</title>
+<style>
+:root {
+  --bg:#0d1117; --card:#161b22; --line:#30363d; --fg:#e6edf3; --dim:#8b949e;
+  --acc:#3fb950; --acc-dark:#04260f; --blue:#58a6ff; --red:#f85149; --amber:#d29922;
+  --safe-b: env(safe-area-inset-bottom, 0px);
+}
+* { box-sizing:border-box; -webkit-tap-highlight-color:transparent; }
+html,body { margin:0; height:100%; }
+body { font-family:-apple-system,'Segoe UI',Roboto,sans-serif; background:var(--bg); color:var(--fg);
+  display:flex; flex-direction:column; overscroll-behavior:none; }
+header { display:flex; align-items:center; justify-content:space-between; padding:12px 16px;
+  border-bottom:1px solid var(--line); position:sticky; top:0; background:var(--bg); z-index:10; }
+header h1 { font-size:17px; margin:0; } header h1 span { color:var(--acc); }
+#app { flex:1; overflow-y:auto; padding:16px 14px calc(24px + var(--safe-b)); max-width:560px; width:100%; margin:0 auto; }
+.card { background:var(--card); border:1px solid var(--line); border-radius:14px; padding:16px; margin-bottom:12px; }
+h2 { font-size:14px; color:var(--dim); text-transform:uppercase; letter-spacing:.06em; margin:0 0 12px; }
+h3 { margin:0 0 6px; font-size:16px; }
+.dim { color:var(--dim); } .small { font-size:12px; }
+button { font-family:inherit; cursor:pointer; border:none; border-radius:12px; font-size:15px; }
+.btn { background:var(--card); border:1px solid var(--line); color:var(--fg); padding:12px 16px; width:100%; margin-bottom:8px; text-align:left; }
+.btn-primary { background:var(--acc); color:var(--acc-dark); font-weight:700; padding:14px 16px; width:100%; text-align:center; }
+.btn-ghost { background:none; color:var(--blue); padding:8px 10px; font-size:14px; }
+.btn-danger { background:none; color:var(--red); padding:8px 10px; font-size:14px; }
+input, select, textarea { background:var(--bg); color:var(--fg); border:1px solid var(--line); border-radius:10px;
+  padding:12px; font-size:16px; width:100%; margin-bottom:10px; font-family:inherit; }
+textarea { min-height:72px; resize:vertical; }
+label { font-size:13px; color:var(--dim); display:block; margin-bottom:4px; }
+.row { display:flex; gap:8px; } .row > * { flex:1; }
+.chips { display:flex; gap:8px; overflow-x:auto; padding-bottom:6px; margin-bottom:10px; }
+.chip { flex:0 0 auto; background:var(--card); border:1px solid var(--line); color:var(--fg);
+  border-radius:99px; padding:10px 16px; font-size:15px; }
+.chip.active { background:var(--blue); color:#06233f; font-weight:700; border-color:var(--blue); }
+.evgrid { display:grid; grid-template-columns:1fr 1fr 1fr; gap:8px; }
+.evbtn { padding:16px 6px; border-radius:12px; background:var(--card); border:1px solid var(--line);
+  color:var(--fg); font-size:13px; line-height:1.25; min-height:62px; }
+.evbtn b { display:block; font-size:19px; margin-bottom:2px; }
+.evbtn.pos { border-color:#2ea04366; } .evbtn.neg { border-color:#f8514955; }
+.evbtn:active { transform:scale(.96); background:#1c2330; }
+.clock { display:flex; align-items:center; justify-content:space-between; gap:10px; }
+.clock .time { font-size:34px; font-weight:700; font-variant-numeric:tabular-nums; }
+.feed { max-height:180px; overflow-y:auto; font-size:14px; }
+.feed div { padding:6px 0; border-bottom:1px solid var(--line); display:flex; justify-content:space-between; gap:8px; }
+.badge { background:var(--acc); color:var(--acc-dark); font-weight:700; border-radius:8px; padding:2px 10px; font-size:13px; }
+.pill { background:var(--bg); border:1px solid var(--line); border-radius:99px; padding:2px 10px; font-size:12px; color:var(--dim); }
+.slider-row { display:grid; grid-template-columns:110px 1fr 28px; gap:10px; align-items:center; margin-bottom:8px; font-size:14px; }
+input[type=range] { width:100%; margin:0; padding:0; accent-color:var(--acc); }
+.verdict { display:grid; grid-template-columns:1fr 1fr 1fr; gap:8px; margin-top:6px; }
+.verdict button { padding:12px 4px; font-size:13px; font-weight:700; background:var(--card); border:1px solid var(--line); color:var(--fg); }
+.verdict .v-sign.on { background:var(--acc); color:var(--acc-dark); }
+.verdict .v-watch.on { background:var(--amber); color:#2b1d00; }
+.verdict .v-pass.on { background:var(--red); color:#2b0502; }
+.topbar { display:flex; justify-content:space-between; align-items:center; margin-bottom:12px; }
+.session-item { display:flex; justify-content:space-between; align-items:center; gap:10px; }
+.muted-link { color:var(--dim); font-size:12px; text-align:center; margin-top:18px; }
+.toast { position:fixed; left:50%; bottom:calc(28px + var(--safe-b)); transform:translateX(-50%);
+  background:var(--fg); color:var(--bg); padding:10px 18px; border-radius:99px; font-size:14px;
+  opacity:0; transition:opacity .25s; pointer-events:none; z-index:50; max-width:90vw; }
+.toast.show { opacity:1; }
+.lock { text-align:center; padding:8px 0; }
+.lock .big { font-size:40px; }
+</style>
+</head>
+<body>
+<header>
+  <h1>Scout<span>Pad</span></h1>
+  <div id="hdrRight" class="small dim"></div>
+</header>
+<div id="app"></div>
+<div id="toast" class="toast"></div>
+<script src="app.js"></script>
+<script>
+if ('serviceWorker' in navigator) navigator.serviceWorker.register('sw.js');
+</script>
+</body>
+</html>

--- a/scoutpad/manifest.webmanifest
+++ b/scoutpad/manifest.webmanifest
@@ -1,0 +1,15 @@
+{
+  "name": "ScoutPad — il taccuino digitale dello scout",
+  "short_name": "ScoutPad",
+  "description": "Tagging live, valutazioni e report di scouting professionali. Funziona offline, a bordo campo.",
+  "start_url": "./",
+  "scope": "./",
+  "display": "standalone",
+  "orientation": "portrait",
+  "background_color": "#0d1117",
+  "theme_color": "#0d1117",
+  "icons": [
+    { "src": "icon.svg", "sizes": "any", "type": "image/svg+xml", "purpose": "any" },
+    { "src": "icon.svg", "sizes": "any", "type": "image/svg+xml", "purpose": "maskable" }
+  ]
+}

--- a/scoutpad/package.json
+++ b/scoutpad/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "scoutpad",
+  "version": "0.1.0",
+  "description": "Il taccuino digitale dello scout: tagging live, valutazioni e report. PWA offline-first, zero backend.",
+  "type": "module",
+  "scripts": {
+    "start": "node serve.js",
+    "test": "node test/smoke.mjs"
+  },
+  "devDependencies": {
+    "jsdom": "^24.0.0"
+  },
+  "license": "MIT"
+}

--- a/scoutpad/serve.js
+++ b/scoutpad/serve.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+// Mini server statico per provare ScoutPad in locale: node serve.js [porta]
+import http from 'node:http';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.dirname(fileURLToPath(import.meta.url));
+const TYPES = {
+  '.html': 'text/html; charset=utf-8', '.js': 'text/javascript', '.svg': 'image/svg+xml',
+  '.webmanifest': 'application/manifest+json', '.json': 'application/json',
+};
+const port = Number(process.argv[2] || 8080);
+
+http.createServer(async (req, res) => {
+  const rel = decodeURIComponent(new URL(req.url, 'http://x').pathname);
+  const file = path.join(ROOT, rel === '/' ? 'index.html' : rel);
+  if (!file.startsWith(ROOT)) { res.writeHead(403); return res.end(); }
+  try {
+    const body = await readFile(file);
+    res.writeHead(200, { 'content-type': TYPES[path.extname(file)] || 'application/octet-stream' });
+    res.end(body);
+  } catch {
+    res.writeHead(404); res.end('not found');
+  }
+}).listen(port, () => console.log(`ScoutPad: http://localhost:${port}`));

--- a/scoutpad/sw.js
+++ b/scoutpad/sw.js
@@ -1,0 +1,26 @@
+// Offline-first service worker: l'app deve funzionare a bordo campo senza rete.
+const CACHE = 'scoutpad-v1';
+const SHELL = ['./', './index.html', './app.js', './manifest.webmanifest', './icon.svg'];
+
+self.addEventListener('install', (e) => {
+  e.waitUntil(caches.open(CACHE).then((c) => c.addAll(SHELL)).then(() => self.skipWaiting()));
+});
+
+self.addEventListener('activate', (e) => {
+  e.waitUntil(
+    caches.keys()
+      .then((keys) => Promise.all(keys.filter((k) => k !== CACHE).map((k) => caches.delete(k))))
+      .then(() => self.clients.claim()),
+  );
+});
+
+self.addEventListener('fetch', (e) => {
+  if (e.request.method !== 'GET') return;
+  e.respondWith(
+    caches.match(e.request).then((hit) => hit || fetch(e.request).then((res) => {
+      const copy = res.clone();
+      caches.open(CACHE).then((c) => c.put(e.request, copy));
+      return res;
+    }).catch(() => caches.match('./index.html'))),
+  );
+});

--- a/scoutpad/test/smoke.mjs
+++ b/scoutpad/test/smoke.mjs
@@ -1,0 +1,79 @@
+import { JSDOM } from 'jsdom';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+const html = readFileSync(path.join(ROOT, 'index.html'), 'utf8')
+  .replace('<script src="app.js"></script>', '')
+  .replace(/<script>[\s\S]*?serviceWorker[\s\S]*?<\/script>/, '');
+const dom = new JSDOM(html, { url: 'https://localhost/', runScripts: 'outside-only', pretendToBeVisual: true });
+const { window } = dom;
+
+window.confirm = () => true;
+import('node:crypto').then(()=>{});
+const { webcrypto } = await import('node:crypto');
+Object.defineProperty(window, 'crypto', { value: webcrypto, configurable: true });
+window.eval(readFileSync(path.join(ROOT, 'app.js'), 'utf8'));
+const $ = (s) => window.document.querySelector(s);
+const click = (s) => { const el = $(s); if (!el) throw new Error('missing element ' + s); el.dispatchEvent(new window.Event('click', { bubbles: true })); };
+
+// Home → setup
+if (!$('#newMatch')) throw new Error('home: no newMatch button');
+click('#newMatch');
+if (!$('#fHome')) throw new Error('setup view not rendered');
+// One player row should exist after setupAddRow
+if (!$('.player-row')) throw new Error('no player row');
+$('#fHome').value = 'Cesena U19'; $('#fAway').value = 'Rimini U19'; $('#fComp').value = 'Primavera 2';
+$('.pNum').value = '10'; $('.pName').value = 'Mario Rossi'; $('.pPos').value = 'Trequartista';
+click('#startMatch');
+if (!$('#clockTime')) throw new Error('live view not rendered');
+// Start clock, tag events
+click('#clockToggle');
+click('[data-ev="goal"]');
+click('[data-ev="dribble_won"]');
+click('[data-ev="duel_lost"]');
+const feedTxt = $('.feed').textContent;
+if (!feedTxt.includes('Gol') || !feedTxt.includes('Mario Rossi')) throw new Error('feed missing events: ' + feedTxt);
+// Undo
+click('#undo');
+if ($('.feed').textContent.includes('Duello perso')) throw new Error('undo failed');
+// Note
+$('#quickNote').value = 'gran movimento';
+click('#addNote');
+// Eval
+click('#goEval');
+if (!$('#evalNotes')) throw new Error('eval view not rendered');
+click('[data-verdict="sign"]');
+const range = $('[data-score="tecnica"]');
+range.value = '8'; range.dispatchEvent(new window.Event('input', { bubbles: true }));
+$('#evalNotes').value = 'Ottimo piede'; $('#evalNotes').dispatchEvent(new window.Event('input', { bubbles: true }));
+// Report (download path: jsdom lacks share; URL.createObjectURL shim)
+window.URL.createObjectURL = () => 'blob:fake'; window.URL.revokeObjectURL = () => {};
+let downloaded = null;
+const origCreate = window.document.createElement.bind(window.document);
+window.document.createElement = (tag) => { const el = origCreate(tag); if (tag === 'a') { el.click = () => { downloaded = el.download; }; } return el; };
+click('#makeReport');
+if (!downloaded) throw new Error('report not generated');
+console.log('downloaded:', downloaded);
+// State persisted
+const st = JSON.parse(window.localStorage.getItem('scoutpad-v1'));
+if (st.reports !== 1) throw new Error('reports counter not incremented');
+const sess = st.sessions[0];
+if (sess.events.length !== 2 || sess.notes.length !== 1) throw new Error('session data wrong: ' + JSON.stringify({e: sess.events.length, n: sess.notes.length}));
+const ev = Object.values(sess.evals)[0];
+if (ev.verdict !== 'sign' || ev.scores.tecnica !== 8 || ev.notes !== 'Ottimo piede') throw new Error('eval not saved: ' + JSON.stringify(ev));
+// Paywall after 3 reports: generate two more via UI, fourth attempt must lock
+click('#makeReport');
+click('#makeReport');
+click('#makeReport');
+if (!$('#licKey')) throw new Error('paywall not shown after free limit');
+// License activation (key from genkey for this email with default secret)
+$('#licEmail').value = 'mirkotornani@gmail.com';
+$('#licKey').value = '6B82-D767-BCBE-10FA';
+click('#activate');
+await new Promise((r) => setTimeout(r, 300));
+const st2 = JSON.parse(window.localStorage.getItem('scoutpad-v1'));
+if (!st2.license) throw new Error('license not activated');
+console.log('license activated for', st2.license.email);
+console.log('ALL SMOKE TESTS PASSED');

--- a/scoutpad/tools/genkey.js
+++ b/scoutpad/tools/genkey.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+// Genera una chiave di licenza ScoutPad PRO per l'email dell'acquirente.
+// Il secret DEVE coincidere con LICENSE_SECRET in app.js (cambialo in entrambi
+// prima di vendere). Uso:
+//   SCOUTPAD_SECRET=il-tuo-secret node tools/genkey.js cliente@email.it
+import { createHmac } from 'node:crypto';
+
+const email = process.argv[2];
+if (!email) {
+  console.error('Uso: node tools/genkey.js <email-acquirente>');
+  process.exit(1);
+}
+const secret = process.env.SCOUTPAD_SECRET || 'scoutpad-change-me';
+const hex = createHmac('sha256', secret)
+  .update(email.trim().toLowerCase())
+  .digest('hex')
+  .slice(0, 16)
+  .toUpperCase();
+console.log(`Email:   ${email.trim().toLowerCase()}`);
+console.log(`Licenza: ${hex.match(/.{4}/g).join('-')}`);
+if (secret === 'scoutpad-change-me') {
+  console.error('\nATTENZIONE: stai usando il secret di default. Cambialo (env SCOUTPAD_SECRET + LICENSE_SECRET in app.js) prima di vendere.');
+}


### PR DESCRIPTION
## Cosa contiene

### ScoutPad — `scoutpad/` (distribuibile subito)
PWA mobile offline-first per scout a bordo campo nei dilettanti/giovanili: tagging live a un tocco, scheda di valutazione, report HTML condivisibile su WhatsApp. Freemium integrato (3 report gratis, licenza PRO a vita via chiavi HMAC, pronto per Gumroad). Zero dipendenze a runtime, zero backend.

**Appena questa PR è mergiata, l'app è online su https://mtornani.github.io/App1/scoutpad/** — il Pages già attivo sul repo (deploy from branch: main) serve i file statici senza modifiche alle impostazioni.

### OpenScout — `openscout/`
Piattaforma di scouting e match analysis su dati StatsBomb open-data (metriche per-90, percentili, rating, similarity engine, xG race, pass network) + motore di Eligibility Intelligence che generalizza Radar SMR a qualsiasi federazione. CLI + web UI + API JSON, zero dipendenze npm. Strategia di mercato in `openscout/STRATEGY.md`.

## Verifiche
- OpenScout: 7/7 unit test (`node:test`), testato end-to-end con Euro 2024 (51 partite, 498 giocatori)
- ScoutPad: smoke test jsdom dell'intero flusso utente (partita → tagging → valutazione → report → paywall → attivazione licenza)

## Dopo il merge
1. Apri https://mtornani.github.io/App1/scoutpad/ dal telefono → "Aggiungi a schermata Home"
2. Per vendere: crea il prodotto Gumroad, imposta `BUY_URL` e cambia `LICENSE_SECRET` in `scoutpad/app.js` (istruzioni in `scoutpad/README.md`)

https://claude.ai/code/session_01AQgxJqr85UXXKRT11sKozM

---
_Generated by [Claude Code](https://claude.ai/code/session_01AQgxJqr85UXXKRT11sKozM)_